### PR TITLE
feat: add unauthenticated login and settings pages

### DIFF
--- a/minesweeper-ui/js/i18n.js
+++ b/minesweeper-ui/js/i18n.js
@@ -1,0 +1,25 @@
+import en from './locales/en.js';
+import fr from './locales/fr.js';
+
+const translations = { en, fr };
+
+const LangContext = React.createContext();
+
+function LangProvider({ children }) {
+  const [lang, setLang] = React.useState(localStorage.getItem('lang') || 'en');
+
+  const changeLang = (l) => {
+    localStorage.setItem('lang', l);
+    setLang(l);
+  };
+
+  const t = translations[lang];
+
+  return (
+    <LangContext.Provider value={{ lang, changeLang, t }}>
+      {children}
+    </LangContext.Provider>
+  );
+}
+
+export { LangContext, LangProvider };

--- a/minesweeper-ui/js/index.jsx
+++ b/minesweeper-ui/js/index.jsx
@@ -1,10 +1,104 @@
+const { HashRouter, Routes, Route, Navigate, Link } = ReactRouterDOM;
+
+import { LangProvider, LangContext } from './i18n.js';
+
 function App() {
+  const [keycloak, setKeycloak] = React.useState(null);
+  const [authenticated, setAuthenticated] = React.useState(false);
+
+  React.useEffect(() => {
+    const kc = new Keycloak();
+    kc.init({ onLoad: 'check-sso', checkLoginIframe: false })
+      .then((auth) => {
+        setAuthenticated(auth);
+        setKeycloak(kc);
+      })
+      .catch(() => {
+        setKeycloak(kc);
+      });
+  }, []);
+
+  if (!keycloak) {
+    return null;
+  }
+
+  const login = () => keycloak.login({ idpHint: 'google' });
+
+  const RequireAuth = ({ children }) =>
+    authenticated ? children : <Navigate to="/login" />;
+
+  const RequireUnauth = ({ children }) =>
+    authenticated ? <Navigate to="/" /> : children;
+
+  return (
+    <LangProvider>
+      <HashRouter>
+        <Routes>
+          <Route
+            path="/login"
+            element={
+              <RequireUnauth>
+                <LoginPage onLogin={login} />
+              </RequireUnauth>
+            }
+          />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route
+            path="/"
+            element={
+              <RequireAuth>
+                <Home />
+              </RequireAuth>
+            }
+          />
+          <Route path="*" element={<Navigate to="/" />} />
+        </Routes>
+      </HashRouter>
+    </LangProvider>
+  );
+}
+
+function Home() {
+  const { t } = React.useContext(LangContext);
   return (
     <div>
-      <h1>MineSweeper MMO</h1>
+      <h1>{t.title}</h1>
+      <nav>
+        <Link to="/settings">{t.settings}</Link>
+      </nav>
+    </div>
+  );
+}
+
+function LoginPage({ onLogin }) {
+  const { t } = React.useContext(LangContext);
+  return (
+    <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+      <button onClick={onLogin}>{t.login}</button>
+      <div style={{ marginTop: '1rem' }}>
+        <Link to="/settings">{t.settings}</Link>
+      </div>
+    </div>
+  );
+}
+
+function SettingsPage() {
+  const { lang, changeLang, t } = React.useContext(LangContext);
+  return (
+    <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+      <h2>{t.settings}</h2>
+      <div>
+        <button onClick={() => changeLang('en')} disabled={lang === 'en'}>
+          <span className="fi fi-gb"></span> {t.english}
+        </button>
+        <button onClick={() => changeLang('fr')} disabled={lang === 'fr'}>
+          <span className="fi fi-fr"></span> {t.french}
+        </button>
+      </div>
     </div>
   );
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);
+

--- a/minesweeper-ui/js/locales/en.js
+++ b/minesweeper-ui/js/locales/en.js
@@ -1,0 +1,8 @@
+export default {
+  "title": "MineSweeper MMO",
+  "login": "Login with Google",
+  "settings": "Settings",
+  "language": "Language",
+  "english": "English",
+  "french": "French"
+};

--- a/minesweeper-ui/js/locales/fr.js
+++ b/minesweeper-ui/js/locales/fr.js
@@ -1,0 +1,8 @@
+export default {
+  "title": "D\u00E9mineur MMO",
+  "login": "Connexion via Google",
+  "settings": "Param\u00E8tres",
+  "language": "Langue",
+  "english": "Anglais",
+  "french": "Fran\u00E7ais"
+};

--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -14,6 +14,6 @@
     <script src="../node_modules/react-dom/umd/react-dom.development.js"></script>
     <script src="../node_modules/react-router-dom/umd/react-router-dom.development.js"></script>
     <script src="../node_modules/keycloak-js/dist/keycloak.js"></script>
-    <script type="text/babel" data-presets="react" src="js/index.jsx"></script>
+    <script type="text/babel" data-presets="react" data-type="module" src="js/index.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add client-side routing with Keycloak auth checks
- provide Google login button
- add settings page to switch between FR/EN
- externalize i18n translations into resource files with dedicated logic module

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ecdfc19d8832cae238999261391b0