### PR TITLE
fix: include router dependency

### DIFF
--- a/minesweeper-ui/build.js
+++ b/minesweeper-ui/build.js
@@ -18,6 +18,7 @@ mkdirSync('dist/vendor', { recursive: true });
 cpSync('node_modules/@babel/standalone/babel.min.js', 'dist/vendor/babel.min.js');
 cpSync('node_modules/react/umd/react.development.js', 'dist/vendor/react.development.js');
 cpSync('node_modules/react-dom/umd/react-dom.development.js', 'dist/vendor/react-dom.development.js');
+cpSync('node_modules/@remix-run/router/dist/router.umd.js', 'dist/vendor/router.umd.js');
 cpSync('node_modules/react-router/dist/umd/react-router.development.js', 'dist/vendor/react-router.development.js');
 cpSync(
   'node_modules/react-router-dom/dist/umd/react-router-dom.development.js',

--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -13,6 +13,7 @@
     <script src="vendor/babel.min.js"></script>
     <script src="vendor/react.development.js"></script>
     <script src="vendor/react-dom.development.js"></script>
+    <script src="vendor/router.umd.js"></script>
     <script src="vendor/react-router.development.js"></script>
     <script src="vendor/react-router-dom.development.js"></script>
     <script type="module">


### PR DESCRIPTION
## Summary
- fix crash by bundling @remix-run/router for HashRouter
- load router library before react-router scripts

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688edf468618832cbc968819d8c430b9