### PR TITLE
feat: use Mouse Memoirs font by default

### DIFF
--- a/minesweeper-ui/build.js
+++ b/minesweeper-ui/build.js
@@ -37,3 +37,6 @@ cpSync('node_modules/flag-icons/css', 'dist/vendor/flag-icons/css', {
 cpSync('node_modules/flag-icons/flags', 'dist/vendor/flag-icons/flags', {
   recursive: true,
 });
+cpSync('node_modules/@fontsource/mouse-memoirs', 'dist/vendor/mouse-memoirs', {
+  recursive: true,
+});

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -1,5 +1,7 @@
+@import url("../vendor/mouse-memoirs/index.css");
+
 body {
-  font-family: sans-serif;
+  font-family: "Mouse Memoirs", sans-serif;
   margin: 0;
   padding: 0;
 }

--- a/minesweeper-ui/package-lock.json
+++ b/minesweeper-ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@babel/standalone": "^7.28.1",
+        "@fontsource/mouse-memoirs": "^5.2.6",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "flag-icons": "^7.5.0",
         "keycloak-js": "^26.0.0",
@@ -24,6 +25,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@fontsource/mouse-memoirs": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/mouse-memoirs/-/mouse-memoirs-5.2.6.tgz",
+      "integrity": "sha512-C8ShlyPo1NJ1+OrZQTM8wPbBjtx1kfb3+Az8aJUcindvCnqDeOfghXuejFUdNb8+XfaVxjOxW5sfkivP2PDw9A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {

--- a/minesweeper-ui/package.json
+++ b/minesweeper-ui/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/standalone": "^7.28.1",
+    "@fontsource/mouse-memoirs": "^5.2.6",
     "@fortawesome/fontawesome-free": "^6.7.2",
     "flag-icons": "^7.5.0",
     "keycloak-js": "^26.0.0",


### PR DESCRIPTION
## Summary
- add self-hosted Mouse Memoirs font dependency
- copy font files during build and use as default UI font

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f0f0cddc8832c9ad7cb09a04531ec