### PR TITLE
Fix back button on settings page and refine button styling

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -17,6 +17,8 @@ h1 {
   font-size: 4rem;
   color: inherit;
   text-decoration: none;
+  cursor: pointer;
+  z-index: 10;
 }
 
 .settings-page {
@@ -37,12 +39,27 @@ h1 {
   background: none;
   border: none;
   font-size: 4rem;
-  cursor: pointer;
+  opacity: 0.5;
 }
 
-.flag-button:disabled {
-  opacity: 0.5;
-  cursor: default;
+.flag-button.active {
+  opacity: 1;
+}
+
+button {
+  border: none;
+  font-family: inherit;
+  background: none;
+  cursor: pointer;
+  transition: font-size 0.2s, transform 0.1s;
+}
+
+button:hover {
+  font-size: 1.05em;
+}
+
+button:active {
+  transform: scale(0.95);
 }
 
 .logout-container {

--- a/minesweeper-ui/js/index.jsx
+++ b/minesweeper-ui/js/index.jsx
@@ -117,16 +117,14 @@ function SettingsPage({ authenticated, onLogout }) {
     <div className="settings-page">
       <div className="language-selection">
         <button
-          className="flag-button"
+          className={`flag-button ${lang === 'en' ? 'active' : ''}`}
           onClick={() => changeLang('en')}
-          disabled={lang === 'en'}
         >
           <span className="fi fi-gb"></span>
         </button>
         <button
-          className="flag-button"
+          className={`flag-button ${lang === 'fr' ? 'active' : ''}`}
           onClick={() => changeLang('fr')}
-          disabled={lang === 'fr'}
         >
           <span className="fi fi-fr"></span>
         </button>


### PR DESCRIPTION
## Summary
- make back button on settings page clickable
- show active language flag as opaque and others semi-transparent
- restyle buttons with borderless default font, hover enlargement and active click effect

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f1514286c832cbd58532ee1be37ea