### PR TITLE
Refine login screen and disable zoom

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -1,9 +1,22 @@
 @import url("../vendor/mouse-memoirs/index.css");
 
+html,
 body {
-  font-family: "Mouse Memoirs", sans-serif;
+  overflow: hidden;
   margin: 0;
   padding: 0;
+}
+
+* {
+  scrollbar-width: none;
+}
+
+*::-webkit-scrollbar {
+  display: none;
+}
+
+body {
+  font-family: "Mouse Memoirs", sans-serif;
 }
 
 h1 {
@@ -51,15 +64,22 @@ button {
   font-family: inherit;
   background: none;
   cursor: pointer;
-  transition: font-size 0.2s, transform 0.1s;
+  transition: transform 0.1s;
 }
 
 button:hover {
-  font-size: 1.05em;
+  transform: scale(1.05);
 }
 
 button:active {
   transform: scale(0.95);
+}
+
+.login-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
 }
 
 .logout-container {

--- a/minesweeper-ui/js/index.jsx
+++ b/minesweeper-ui/js/index.jsx
@@ -80,6 +80,9 @@ function SettingsButton() {
       </Link>
     );
   }
+  if (location.pathname === '/login') {
+    return null;
+  }
   return (
     <Link to="/settings" className="settings-button" aria-label="Settings">
       <i className="fa-solid fa-gear"></i>
@@ -102,11 +105,8 @@ function Home() {
 function LoginPage({ onLogin }) {
   const { t } = React.useContext(LangContext);
   return (
-    <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+    <div className="login-page">
       <button onClick={onLogin}>{t.login}</button>
-      <div style={{ marginTop: '1rem' }}>
-        <Link to="/settings">{t.settings}</Link>
-      </div>
     </div>
   );
 }

--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>MineSweeper UI</title>
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css" />


### PR DESCRIPTION
## Summary
- Center login page around a single Google authentication button
- Hide settings button on login screen
- Disable browser zoom and scrollbars, and ensure button hover/click doesn't shift layout

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_688f16919504832cb93d7d0dd29d196e