### PR TITLE
Add loading screen and enhance auth buttons

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -17,6 +17,8 @@ body {
 
 body {
   font-family: "Mouse Memoirs", sans-serif;
+  background-color: #000;
+  color: #fff;
 }
 
 h1 {
@@ -84,4 +86,28 @@ button:active {
 
 .logout-container {
   margin-top: 2rem;
+}
+
+.login-page button,
+.logout-container button {
+  font-size: 2rem;
+  padding: 1rem 2rem;
+}
+
+#root {
+  display: none;
+}
+
+#loading-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  color: #fff;
+  font-size: 2rem;
 }

--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="vendor/flag-icons/css/flag-icons.min.css" />
   </head>
   <body>
+    <div id="loading-screen">Loading...</div>
     <div id="root"></div>
     <script src="config.js"></script>
     <script src="vendor/babel.min.js"></script>
@@ -25,5 +26,11 @@
       window.Keycloak = Keycloak;
     </script>
     <script type="text/babel" data-presets="react" data-type="module" src="js/index.jsx"></script>
+    <script>
+      window.addEventListener('load', function () {
+        document.getElementById('loading-screen').style.display = 'none';
+        document.getElementById('root').style.display = 'block';
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- enlarge login/logout buttons for better tap targets
- default to dark background with contrasting text
- show loading screen until all resources complete loading

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f199761f4832cb2d01206236fd01f