### PR TITLE
feat(api): add game lifecycle endpoints

### DIFF
--- a/minesweeper-api/pom.xml
+++ b/minesweeper-api/pom.xml
@@ -39,6 +39,18 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm-panache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
@@ -1,0 +1,61 @@
+package com.minesweeper;
+
+import com.minesweeper.dto.NewGameRequest;
+import com.minesweeper.entity.Game;
+import com.minesweeper.entity.Mine;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Path("/games")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class GameResource {
+
+    @GET
+    public List<Game> listGames() {
+        return Game.listAll();
+    }
+
+    @POST
+    @Path("/new")
+    @Transactional
+    public Response newGame(NewGameRequest request) {
+        if (request == null || request.title == null || request.title.isBlank()
+                || request.width <= 0 || request.height <= 0 || request.bombs <= 0) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        if (Game.count("endDate is null") > 0) {
+            return Response.status(Response.Status.CONFLICT).entity("Game already in progress").build();
+        }
+        Game game = new Game();
+        game.id = UUID.randomUUID();
+        game.title = request.title;
+        game.width = request.width;
+        game.height = request.height;
+        game.startDate = LocalDateTime.now();
+        game.persist();
+
+        Set<String> positions = new HashSet<>();
+        Random random = new Random();
+        while (positions.size() < request.bombs) {
+            int x = random.nextInt(request.width);
+            int y = random.nextInt(request.height);
+            String key = x + "," + y;
+            if (positions.add(key)) {
+                Mine mine = new Mine();
+                mine.id = UUID.randomUUID();
+                mine.game = game;
+                mine.x = x;
+                mine.y = y;
+                mine.persist();
+            }
+        }
+
+        return Response.status(Response.Status.CREATED).entity(game).build();
+    }
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/NewGameRequest.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/NewGameRequest.java
@@ -1,0 +1,8 @@
+package com.minesweeper.dto;
+
+public class NewGameRequest {
+    public String title;
+    public int width;
+    public int height;
+    public int bombs;
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/entity/Game.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/entity/Game.java
@@ -1,0 +1,32 @@
+package com.minesweeper.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "games")
+public class Game extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue
+    public UUID id;
+
+    @Column(unique = true)
+    public String title;
+
+    public int width;
+
+    public int height;
+
+    @Column(name = "start_date")
+    public LocalDateTime startDate;
+
+    @Column(name = "end_date")
+    public LocalDateTime endDate;
+
+    @OneToMany(mappedBy = "game", cascade = CascadeType.ALL)
+    public List<Mine> mines;
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/entity/Mine.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/entity/Mine.java
@@ -1,0 +1,26 @@
+package com.minesweeper.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "mines")
+public class Mine extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue
+    public UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "id_game")
+    public Game game;
+
+    public int x;
+
+    public int y;
+
+    @ManyToOne
+    @JoinColumn(name = "foundby")
+    public Player foundBy;
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/entity/Player.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/entity/Player.java
@@ -1,0 +1,23 @@
+package com.minesweeper.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "players")
+public class Player extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_player")
+    public String idPlayer;
+
+    @Column(unique = true)
+    public String name;
+
+    @Column(name = "last_connection")
+    public LocalDateTime lastConnection;
+}


### PR DESCRIPTION
## Summary
- add database entities for players, games and mines
- implement POST /games/new and GET /games
- wire new endpoints with Panache and JSON support

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.15.1)*

------
https://chatgpt.com/codex/tasks/task_e_688f4313b58c832cabccea58bee04195