### PR TITLE
feat(api): add game and scan endpoints

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
@@ -1,0 +1,73 @@
+package com.minesweeper;
+
+import com.minesweeper.dto.GameInfo;
+import com.minesweeper.dto.NewGameRequest;
+import com.minesweeper.entity.Game;
+import com.minesweeper.entity.Mine;
+import com.minesweeper.repository.GameRepository;
+import com.minesweeper.repository.MineRepository;
+import io.quarkus.security.Authenticated;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Path("/games")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class GameResource {
+
+    @Inject
+    GameRepository gameRepository;
+
+    @Inject
+    MineRepository mineRepository;
+
+    @GET
+    @Authenticated
+    public List<GameInfo> listGames() {
+        return gameRepository.listOngoing().stream()
+                .map(g -> new GameInfo(g.getId(), g.getTitle(), g.getWidth(), g.getHeight()))
+                .toList();
+    }
+
+    @POST
+    @Path("/new")
+    @RolesAllowed("admin")
+    @Transactional
+    public GameInfo createGame(NewGameRequest request) {
+        Game game = new Game();
+        game.setId(UUID.randomUUID().toString());
+        game.setTitle(request.title());
+        game.setWidth(request.width());
+        game.setHeight(request.height());
+        game.setMineCount(request.mineCount());
+        game.setStartDate(LocalDateTime.now());
+        game.setEndDate(LocalDateTime.now().plusHours(1));
+        gameRepository.persist(game);
+
+        Random random = new Random();
+        Set<String> positions = new HashSet<>();
+        while (positions.size() < request.mineCount()) {
+            int x = random.nextInt(request.width());
+            int y = random.nextInt(request.height());
+            String key = x + ":" + y;
+            if (positions.add(key)) {
+                Mine mine = new Mine();
+                mine.setId(UUID.randomUUID().toString());
+                mine.setGame(game);
+                mine.setX(x);
+                mine.setY(y);
+                mine.setExploded(false);
+                mineRepository.persist(mine);
+            }
+        }
+
+        return new GameInfo(game.getId(), game.getTitle(), game.getWidth(), game.getHeight());
+    }
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/ScanResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/ScanResource.java
@@ -1,0 +1,96 @@
+package com.minesweeper;
+
+import com.minesweeper.dto.NewScanRequest;
+import com.minesweeper.dto.ScanInfo;
+import com.minesweeper.dto.ScanResult;
+import com.minesweeper.entity.Game;
+import com.minesweeper.entity.Mine;
+import com.minesweeper.entity.Player;
+import com.minesweeper.entity.PlayerScan;
+import com.minesweeper.repository.GameRepository;
+import com.minesweeper.repository.MineRepository;
+import com.minesweeper.repository.PlayerRepository;
+import com.minesweeper.repository.PlayerScanRepository;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Path("/scans")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ScanResource {
+
+    @Inject
+    GameRepository gameRepository;
+
+    @Inject
+    PlayerRepository playerRepository;
+
+    @Inject
+    MineRepository mineRepository;
+
+    @Inject
+    PlayerScanRepository playerScanRepository;
+
+    @GET
+    @Path("/{idGame}")
+    @Authenticated
+    public List<ScanInfo> listScans(@PathParam("idGame") String idGame) {
+        Game game = gameRepository.findById(idGame);
+        if (game == null) {
+            throw new NotFoundException();
+        }
+        return playerScanRepository.list("game", game).stream()
+                .map(scan -> new ScanInfo(scan.getId(), scan.getPlayer().getId(), scan.getX(), scan.getY(),
+                        scan.getScanDate(), scan.getScanRange(), countMines(game, scan.getX(), scan.getY(), scan.getScanRange())))
+                .toList();
+    }
+
+    @POST
+    @Authenticated
+    @Transactional
+    public ScanResult createScan(NewScanRequest request) {
+        Game game = gameRepository.findById(request.gameId());
+        if (game == null) {
+            throw new NotFoundException();
+        }
+        Player player = playerRepository.findById(request.playerId());
+        if (player == null) {
+            player = new Player();
+            player.setId(request.playerId());
+            player.setName(request.playerId());
+            player.setDateLastConnexion(LocalDateTime.now());
+            playerRepository.persist(player);
+        }
+        PlayerScan scan = new PlayerScan();
+        scan.setId(UUID.randomUUID().toString());
+        scan.setGame(game);
+        scan.setPlayer(player);
+        scan.setX(request.x());
+        scan.setY(request.y());
+        scan.setScanRange(request.scanRange());
+        scan.setScanDate(LocalDateTime.now());
+        playerScanRepository.persist(scan);
+
+        int mines = countMines(game, request.x(), request.y(), request.scanRange());
+        return new ScanResult(mines);
+    }
+
+    private int countMines(Game game, int x, int y, int range) {
+        List<Mine> mines = mineRepository.list("game", game);
+        int count = 0;
+        for (Mine m : mines) {
+            double dist = Math.hypot(m.getX() - x, m.getY() - y);
+            if (dist < range) {
+                count++;
+            }
+        }
+        return count;
+    }
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/GameInfo.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/GameInfo.java
@@ -1,0 +1,5 @@
+package com.minesweeper.dto;
+
+public record GameInfo(String id, String title, int width, int height) {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/NewGameRequest.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/NewGameRequest.java
@@ -1,0 +1,5 @@
+package com.minesweeper.dto;
+
+public record NewGameRequest(String title, int width, int height, int mineCount) {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/NewScanRequest.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/NewScanRequest.java
@@ -1,0 +1,5 @@
+package com.minesweeper.dto;
+
+public record NewScanRequest(String gameId, String playerId, int x, int y, int scanRange) {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/ScanInfo.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/ScanInfo.java
@@ -1,0 +1,7 @@
+package com.minesweeper.dto;
+
+import java.time.LocalDateTime;
+
+public record ScanInfo(String id, String playerId, int x, int y, LocalDateTime scanDate, int scanRange, int mineCount) {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/ScanResult.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/ScanResult.java
@@ -1,0 +1,5 @@
+package com.minesweeper.dto;
+
+public record ScanResult(int mineCount) {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/GameRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/GameRepository.java
@@ -1,0 +1,18 @@
+package com.minesweeper.repository;
+
+import com.minesweeper.entity.Game;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@ApplicationScoped
+public class GameRepository implements PanacheRepository<Game> {
+
+    public List<Game> listOngoing() {
+        LocalDateTime now = LocalDateTime.now();
+        return list("startDate <= ?1 and endDate >= ?1", now);
+    }
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/GameRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/GameRepository.java
@@ -1,14 +1,14 @@
 package com.minesweeper.repository;
 
 import com.minesweeper.entity.Game;
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @ApplicationScoped
-public class GameRepository implements PanacheRepository<Game> {
+public class GameRepository implements PanacheRepositoryBase<Game, String> {
 
     public List<Game> listOngoing() {
         LocalDateTime now = LocalDateTime.now();

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/MineRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/MineRepository.java
@@ -1,10 +1,10 @@
 package com.minesweeper.repository;
 
 import com.minesweeper.entity.Mine;
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class MineRepository implements PanacheRepository<Mine> {
+public class MineRepository implements PanacheRepositoryBase<Mine, String> {
 }
 

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/MineRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/MineRepository.java
@@ -1,0 +1,10 @@
+package com.minesweeper.repository;
+
+import com.minesweeper.entity.Mine;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MineRepository implements PanacheRepository<Mine> {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerRepository.java
@@ -1,0 +1,10 @@
+package com.minesweeper.repository;
+
+import com.minesweeper.entity.Player;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PlayerRepository implements PanacheRepository<Player> {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerRepository.java
@@ -1,10 +1,10 @@
 package com.minesweeper.repository;
 
 import com.minesweeper.entity.Player;
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class PlayerRepository implements PanacheRepository<Player> {
+public class PlayerRepository implements PanacheRepositoryBase<Player, String> {
 }
 

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerScanRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerScanRepository.java
@@ -1,0 +1,10 @@
+package com.minesweeper.repository;
+
+import com.minesweeper.entity.PlayerScan;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PlayerScanRepository implements PanacheRepository<PlayerScan> {
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerScanRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerScanRepository.java
@@ -1,10 +1,10 @@
 package com.minesweeper.repository;
 
 import com.minesweeper.entity.PlayerScan;
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class PlayerScanRepository implements PanacheRepository<PlayerScan> {
+public class PlayerScanRepository implements PanacheRepositoryBase<PlayerScan, String> {
 }
 


### PR DESCRIPTION
## Summary
- add repositories and DTOs for games and scans
- create endpoints to manage games and scans
- compute scan indicators based on nearby mines

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_688f68990e7c832cba220c12684b970d