### PR TITLE
Add mine count to game creation form

### DIFF
--- a/minesweeper-ui/js/index.jsx
+++ b/minesweeper-ui/js/index.jsx
@@ -157,7 +157,13 @@ function Home({ keycloak }) {
 function CreateGameForm({ keycloak }) {
   const { t } = React.useContext(LangContext);
   const [show, setShow] = React.useState(false);
-  const [form, setForm] = React.useState({ title: '', width: '', height: '', endDate: '' });
+  const [form, setForm] = React.useState({
+    title: '',
+    width: '',
+    height: '',
+    mineCount: '',
+    endDate: '',
+  });
 
   const open = () => setShow(true);
   const close = () => setShow(false);
@@ -175,6 +181,7 @@ function CreateGameForm({ keycloak }) {
         title: form.title,
         width: Number(form.width),
         height: Number(form.height),
+        mineCount: Number(form.mineCount),
         end_date: form.endDate,
       }),
     }).then(close);
@@ -199,6 +206,10 @@ function CreateGameForm({ keycloak }) {
             <label>
               {t.height}
               <input name="height" value={form.height} onChange={handleChange} />
+            </label>
+            <label>
+              {t.mineCount}
+              <input name="mineCount" value={form.mineCount} onChange={handleChange} />
             </label>
             <label>
               {t.endDate}

--- a/minesweeper-ui/js/locales/en.js
+++ b/minesweeper-ui/js/locales/en.js
@@ -9,6 +9,7 @@ export default {
   "gameTitleLabel": "Title",
   "width": "Width",
   "height": "Height",
+  "mineCount": "Number of mines",
   "endDate": "End date",
   "create": "Create",
   "cancel": "Cancel"

--- a/minesweeper-ui/js/locales/fr.js
+++ b/minesweeper-ui/js/locales/fr.js
@@ -9,6 +9,7 @@ export default {
   "gameTitleLabel": "Titre",
   "width": "Largeur",
   "height": "Hauteur",
+  "mineCount": "Nombre de mines",
   "endDate": "Date de fin",
   "create": "Cr\u00E9er",
   "cancel": "Annuler"


### PR DESCRIPTION
## Summary
- add mine count field to the game creation form
- provide English and French translations for the new label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f6d361c2c832ca1cd52a4b9e23458