### PR TITLE
feat(api): allow specifying end date for new games

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
@@ -31,7 +31,18 @@ public class GameResource {
     @Authenticated
     public List<GameInfo> listGames() {
         return gameRepository.listOngoing().stream()
-                .map(g -> new GameInfo(g.getId(), g.getTitle(), g.getWidth(), g.getHeight()))
+                .map(g -> {
+                    long found = mineRepository.count("game = ?1 and foundBy is not null", g);
+                    return new GameInfo(
+                            g.getId(),
+                            g.getTitle(),
+                            g.getWidth(),
+                            g.getHeight(),
+                            g.getStartDate(),
+                            g.getEndDate(),
+                            g.getMineCount(),
+                            (int) found);
+                })
                 .toList();
     }
 
@@ -68,7 +79,15 @@ public class GameResource {
             }
         }
 
-        return new GameInfo(game.getId(), game.getTitle(), game.getWidth(), game.getHeight());
+        return new GameInfo(
+                game.getId(),
+                game.getTitle(),
+                game.getWidth(),
+                game.getHeight(),
+                game.getStartDate(),
+                game.getEndDate(),
+                game.getMineCount(),
+                0);
     }
 }
 

--- a/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
@@ -46,8 +46,9 @@ public class GameResource {
         game.setWidth(request.width());
         game.setHeight(request.height());
         game.setMineCount(request.mineCount());
-        game.setStartDate(LocalDateTime.now());
-        game.setEndDate(LocalDateTime.now().plusHours(1));
+        LocalDateTime now = LocalDateTime.now();
+        game.setStartDate(now);
+        game.setEndDate(request.endDate() != null ? request.endDate() : now.plusHours(1));
         gameRepository.persist(game);
 
         Random random = new Random();

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/GameInfo.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/GameInfo.java
@@ -1,5 +1,16 @@
 package com.minesweeper.dto;
 
-public record GameInfo(String id, String title, int width, int height) {
+import java.time.LocalDateTime;
+
+public record GameInfo(
+        String id,
+        String title,
+        int width,
+        int height,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        int mineCount,
+        int foundMines
+) {
 }
 

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/NewGameRequest.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/NewGameRequest.java
@@ -1,5 +1,13 @@
 package com.minesweeper.dto;
 
-public record NewGameRequest(String title, int width, int height, int mineCount) {
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record NewGameRequest(
+        String title,
+        int width,
+        int height,
+        int mineCount,
+        @JsonProperty("end_date") LocalDateTime endDate) {
 }
 


### PR DESCRIPTION
## Summary
- allow `end_date` field in new game requests
- honor provided `end_date` when creating games

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688f6ee9810c832c858d96b91e87b124