### PR TITLE
Always show create game button for admins

### DIFF
--- a/minesweeper-ui/js/index.jsx
+++ b/minesweeper-ui/js/index.jsx
@@ -145,12 +145,12 @@ function Home({ keycloak }) {
         </div>
       ) : (
         <>
-          {isAdmin && <CreateGameForm keycloak={keycloak} />}
           <ul>
             {games.map((g) => (
               <li key={g.id}>{g.name || g.id}</li>
             ))}
           </ul>
+          {isAdmin && <CreateGameForm keycloak={keycloak} />}
         </>
       )}
     </div>

--- a/minesweeper-ui/js/index.jsx
+++ b/minesweeper-ui/js/index.jsx
@@ -144,11 +144,14 @@ function Home({ keycloak }) {
           {isAdmin && <CreateGameForm keycloak={keycloak} />}
         </div>
       ) : (
-        <ul>
-          {games.map((g) => (
-            <li key={g.id}>{g.name || g.id}</li>
-          ))}
-        </ul>
+        <>
+          {isAdmin && <CreateGameForm keycloak={keycloak} />}
+          <ul>
+            {games.map((g) => (
+              <li key={g.id}>{g.name || g.id}</li>
+            ))}
+          </ul>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Display the create game form for administrators even when games are already running

## Testing
- `npm test`
- `mvn -q test` *(fails: 'dependencies.dependency.version' missing for Quarkus artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_688f7445b62c832c8fdf464a1c4e1703