### PR TITLE
Display ongoing games

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -217,6 +217,7 @@ button:active {
   justify-content: center;
   align-items: center;
   flex: 1;
+  overflow: auto;
 }
 
 .games-list {

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -205,3 +205,50 @@ button:active {
   justify-content: center;
   margin-bottom: 2rem;
 }
+
+.games-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.games-list-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+}
+
+.games-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.games-list li {
+  margin: 0.5rem 0;
+}
+
+.game-item {
+  display: flex;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+  white-space: nowrap;
+  max-width: 90vw;
+  font-size: 2rem;
+}
+
+.game-prefix,
+.game-suffix {
+  flex-shrink: 0;
+}
+
+.game-title {
+  margin: 0 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/minesweeper-ui/js/index.jsx
+++ b/minesweeper-ui/js/index.jsx
@@ -1,4 +1,12 @@
-const { HashRouter, Routes, Route, Navigate, Link, useLocation } = ReactRouterDOM;
+const {
+  HashRouter,
+  Routes,
+  Route,
+  Navigate,
+  Link,
+  useLocation,
+  useParams,
+} = ReactRouterDOM;
 
 import { LangProvider, LangContext } from '/js/i18n.js';
 
@@ -87,6 +95,14 @@ function App() {
               </RequireAuth>
             }
           />
+          <Route
+            path="/games/:id"
+            element={
+              <RequireAuth>
+                <GamePage keycloak={keycloak} />
+              </RequireAuth>
+            }
+          />
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>
       </HashRouter>
@@ -144,11 +160,27 @@ function Home({ keycloak }) {
           {isAdmin && <CreateGameForm keycloak={keycloak} />}
         </div>
       ) : (
-        <ul>
-          {games.map((g) => (
-            <li key={g.id}>{g.name || g.id}</li>
-          ))}
-        </ul>
+        <div className="games-page">
+          <div className="games-list-container">
+            <ul className="games-list">
+              {games.map((g) => (
+                <li key={g.id}>
+                  <Link to={`/games/${g.id}`} className="game-item">
+                    <span className="game-prefix">
+                      {g.foundMines}/{g.mineCount}:
+                    </span>
+                    <span className="game-title">{g.title}</span>
+                    <span className="game-suffix">
+                      , {new Date(g.endDate).toLocaleString()} ({g.width}L*
+                      {g.height}H)
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {isAdmin && <CreateGameForm keycloak={keycloak} />}
+        </div>
       )}
     </div>
   );
@@ -240,6 +272,15 @@ function LoginPage({ onLogin }) {
   return (
     <div className="login-page">
       <button onClick={onLogin}>{t.login}</button>
+    </div>
+  );
+}
+
+function GamePage() {
+  const { id } = useParams();
+  return (
+    <div className="game-page">
+      <p>{id}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center ongoing games and show details with found/total mines, title, end date, and size
- make each listed game navigate to its detail view
- enlarge font of ongoing game entries for readability
- keep the new game button visible by using a flex column layout

## Testing
- `npm test`
- `mvn -q test` *(fails: dependencies.dependency.version for io.quarkus... is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688f73d3a7d8832cb0e9835095245da6