### PR TITLE
Rename game creation endpoint

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
@@ -47,7 +47,6 @@ public class GameResource {
     }
 
     @POST
-    @Path("/new")
     @RolesAllowed("admin")
     @Transactional
     public GameInfo createGame(NewGameRequest request) {


### PR DESCRIPTION
## Summary
- Remove `/new` suffix from game creation endpoint so POST requests go to `/games`.

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f7e59fca4832c80a9a6f4bc521f82