### PR TITLE
feat(ui): use in-progress background on games screen

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -38,7 +38,8 @@ h1 {
 
 .settings-page,
 .login-page,
-.no-games {
+.no-games,
+.games-page {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -210,6 +211,7 @@ button:active {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url("../images/images_background_gameinprogress.png");
 }
 
 .games-list-container {

--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -13,6 +13,7 @@
     <link rel="preload" as="image" href="images/images_background_login.png" />
     <link rel="preload" as="image" href="images/images_background_parameters.png" />
     <link rel="preload" as="image" href="images/images_background_nogameinprogress.png" />
+    <link rel="preload" as="image" href="images/images_background_gameinprogress.png" />
     <link rel="preload" as="audio" href="sounds/sound_click_1.mp3" />
     <link rel="preload" as="audio" href="sounds/sound_click_2.mp3" />
   </head>


### PR DESCRIPTION
## Summary
- show themed background when there are active games
- preload the game-in-progress background image

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f80c4531c832cbae600e9fc16932f