### PR TITLE
feat(ui): add PWA support

### DIFF
--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -7,6 +7,9 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
     <title>MineSweeper UI</title>
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css" />
     <link rel="stylesheet" href="vendor/flag-icons/css/flag-icons.min.css" />
@@ -37,5 +40,6 @@
         document.getElementById('root').style.display = 'block';
       });
     </script>
+    <script>if("serviceWorker" in navigator){window.addEventListener("load",()=>{navigator.serviceWorker.register("service-worker.js");});}</script>
   </body>
 </html>

--- a/minesweeper-ui/public/manifest.json
+++ b/minesweeper-ui/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "MineSweeper UI",
+  "short_name": "MineSweeper",
+  "start_url": ".",
+  "display": "fullscreen",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "images/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "images/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/minesweeper-ui/public/service-worker.js
+++ b/minesweeper-ui/public/service-worker.js
@@ -1,0 +1,17 @@
+const CACHE_NAME = 'minesweeper-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest with fullscreen display, theme color and icon references
- cache core files with a basic service worker and register it on load
- remove placeholder icon images so real assets can be supplied later

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fbd0a3170832ca77a9d5a06fbf154