### PR TITLE
Fix console warnings in Minesweeper UI

### DIFF
--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -50,7 +50,7 @@ export default function App() {
 
   return (
     <LangProvider>
-      <HashRouter>
+      <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <SettingsButton />
         <AppRouter
           authenticated={authenticated}

--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -9,17 +9,17 @@
     <title>MineSweeper UI</title>
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#000000" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css" />
     <link rel="stylesheet" href="vendor/flag-icons/css/flag-icons.min.css" />
-    <link rel="preload" as="image" href="images/images_background_login.png" />
-    <link rel="preload" as="image" href="images/images_background_parameters.png" />
-    <link rel="preload" as="image" href="images/images_background_nogameinprogress.png" />
-    <link rel="preload" as="image" href="images/images_background_gameinprogress.png" />
-    <link rel="preload" as="image" href="images/images_background_game.png" />
-    <link rel="preload" as="audio" href="sounds/sound_click_1.mp3" />
-    <link rel="preload" as="audio" href="sounds/sound_click_2.mp3" />
+    <link rel="prefetch" as="image" href="images/images_background_login.png" />
+    <link rel="prefetch" as="image" href="images/images_background_parameters.png" />
+    <link rel="prefetch" as="image" href="images/images_background_nogameinprogress.png" />
+    <link rel="prefetch" as="image" href="images/images_background_gameinprogress.png" />
+    <link rel="prefetch" as="image" href="images/images_background_game.png" />
+    <link rel="prefetch" href="sounds/sound_click_1.mp3" />
+    <link rel="prefetch" href="sounds/sound_click_2.mp3" />
   </head>
   <body>
     <div id="loading-screen">Loading...</div>


### PR DESCRIPTION
## Summary
- Enable React Router v7 future flags to remove deprecation warnings.
- Replace deprecated `apple-mobile-web-app-capable` meta with `mobile-web-app-capable` and convert preload tags to prefetch to avoid console warnings.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68900cd2c128832cbb2c4aee1bef7238