### PR TITLE
Fix scan results not updating board

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/ScanResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/ScanResource.java
@@ -2,7 +2,6 @@ package com.minesweeper;
 
 import com.minesweeper.dto.NewScanRequest;
 import com.minesweeper.dto.ScanInfo;
-import com.minesweeper.dto.ScanResult;
 import com.minesweeper.entity.Game;
 import com.minesweeper.entity.Mine;
 import com.minesweeper.entity.Player;
@@ -54,7 +53,7 @@ public class ScanResource {
     @POST
     @Authenticated
     @Transactional
-    public ScanResult createScan(NewScanRequest request) {
+    public ScanInfo createScan(NewScanRequest request) {
         Game game = gameRepository.findById(request.gameId());
         if (game == null) {
             throw new NotFoundException();
@@ -83,7 +82,8 @@ public class ScanResource {
         }
 
         int mines = countMines(game, request.x(), request.y(), request.scanRange());
-        return new ScanResult(mines);
+        return new ScanInfo(scan.getId(), player.getId(), scan.getX(), scan.getY(),
+                scan.getScanDate(), scan.getScanRange(), mines);
     }
 
     private int countMines(Game game, int x, int y, int range) {

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/ScanResult.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/ScanResult.java
@@ -1,5 +1,0 @@
-package com.minesweeper.dto;
-
-public record ScanResult(int mineCount) {
-}
-


### PR DESCRIPTION
## Summary
- return full scan info (coordinates and range) when creating a scan so UI can store and render it
- remove obsolete ScanResult DTO

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable import POM: io.quarkus.platform:quarkus-bom:pom:3.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68901320585c832ca5370154e6b3f79b