### PR TITLE
Avoid storing scan when mine hit

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/dto/ScanInfo.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/ScanInfo.java
@@ -2,6 +2,7 @@ package com.minesweeper.dto;
 
 import java.time.LocalDateTime;
 
-public record ScanInfo(String id, String playerId, int x, int y, LocalDateTime scanDate, int scanRange, int mineCount) {
+public record ScanInfo(String id, String playerId, int x, int y, LocalDateTime scanDate,
+                       int scanRange, int mineCount, boolean exploded) {
 }
 


### PR DESCRIPTION
## Summary
- Add `exploded` field to ScanInfo to notify when a scan hits a mine
- Skip persisting PlayerScan when scanning a mine and flag the response as exploded
- Include `exploded` flag (false) in scan listings for existing scans

## Testing
- `mvn -q test` *(fails: 'dependencies.dependency.version' for io.quarkus:quarkus-rest:jar is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890194c17e4832cb511a32ef029c30a