### PR TITLE
Allow players to update their name

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/PlayerResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PlayerResource.java
@@ -1,0 +1,60 @@
+package com.minesweeper;
+
+import com.minesweeper.dto.PlayerInfo;
+import com.minesweeper.dto.UpdatePlayerRequest;
+import com.minesweeper.entity.Player;
+import com.minesweeper.repository.PlayerRepository;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import java.time.LocalDateTime;
+
+@Path("/players")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PlayerResource {
+
+    @Inject
+    PlayerRepository playerRepository;
+
+    @Inject
+    JsonWebToken jwt;
+
+    @GET
+    @Path("/me")
+    @Authenticated
+    @Transactional
+    public PlayerInfo me() {
+        String id = jwt.getSubject();
+        Player player = playerRepository.findById(id);
+        if (player == null) {
+            player = new Player();
+            player.setId(id);
+            player.setName(id);
+            player.setDateLastConnexion(LocalDateTime.now());
+            playerRepository.persist(player);
+        }
+        return new PlayerInfo(player.getId(), player.getName());
+    }
+
+    @PUT
+    @Path("/me")
+    @Authenticated
+    @Transactional
+    public PlayerInfo updateMe(UpdatePlayerRequest request) {
+        String id = jwt.getSubject();
+        Player player = playerRepository.findById(id);
+        if (player == null) {
+            player = new Player();
+            player.setId(id);
+            player.setDateLastConnexion(LocalDateTime.now());
+            playerRepository.persist(player);
+        }
+        player.setName(request.name());
+        return new PlayerInfo(player.getId(), player.getName());
+    }
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/PlayerInfo.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/PlayerInfo.java
@@ -1,0 +1,3 @@
+package com.minesweeper.dto;
+
+public record PlayerInfo(String id, String name) {}

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/UpdatePlayerRequest.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/UpdatePlayerRequest.java
@@ -1,0 +1,3 @@
+package com.minesweeper.dto;
+
+public record UpdatePlayerRequest(String name) {}

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -291,3 +291,16 @@ button:active {
   flex-direction: column;
   gap: 0.25rem;
 }
+
+.name-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.name-form input {
+  font-size: 1.5rem;
+  padding: 0.5rem;
+}

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -166,7 +166,7 @@ button:active {
 
 .sound-toggle-container {
   position: absolute;
-  bottom: 1rem;
+  top: 5rem;
   right: 1rem;
 }
 

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -167,7 +167,7 @@ button:active {
 .sound-toggle-container {
   position: absolute;
   top: 5rem;
-  right: 1rem;
+  right: 0.5rem;
 }
 
 .sound-toggle {
@@ -186,11 +186,13 @@ button:active {
 }
 
 .action-buttons {
-  margin-top: 2rem;
-  display: flex;
-  gap: 1rem;
+  position: absolute;
+  bottom: 2rem;
+  left: 0;
   width: 100%;
-  justify-content: flex-end;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
 }
 
 .no-games {

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -96,12 +96,7 @@ button:active {
   background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url("../images/images_background_login.png");
 }
 
-.logout-container {
-  margin-top: 2rem;
-}
-
 .login-page button,
-.logout-container button,
 .main-button {
   font-size: 2rem;
   padding: 1rem 2rem;
@@ -171,13 +166,31 @@ button:active {
 
 .sound-toggle-container {
   position: absolute;
-  top: 1rem;
-  left: 1rem;
+  bottom: 1rem;
+  right: 1rem;
 }
 
 .sound-toggle {
   font-size: 3rem;
   color: inherit;
+}
+
+.name-form {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.player-name-label {
+  font-size: 2rem;
+}
+
+.action-buttons {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  justify-content: flex-end;
 }
 
 .no-games {

--- a/minesweeper-ui/js/locales/en.js
+++ b/minesweeper-ui/js/locales/en.js
@@ -4,6 +4,8 @@ export default {
   "language": "Language",
   "english": "English",
   "french": "French",
+  "playerName": "Player name",
+  "save": "Save",
   "noGame": "No game in progress at the moment...",
   "createGame": "Create a game",
   "gameTitleLabel": "Title",

--- a/minesweeper-ui/js/locales/fr.js
+++ b/minesweeper-ui/js/locales/fr.js
@@ -4,6 +4,8 @@ export default {
   "language": "Langue",
   "english": "Anglais",
   "french": "Fran\u00E7ais",
+  "playerName": "Nom du joueur",
+  "save": "Enregistrer",
   "noGame": "Aucune partie en cours pour le moment...",
   "createGame": "Cr\u00E9er une partie",
   "gameTitleLabel": "Titre",

--- a/minesweeper-ui/js/pages/SettingsPage.js
+++ b/minesweeper-ui/js/pages/SettingsPage.js
@@ -49,17 +49,23 @@ export default function SettingsPage({ authenticated, keycloak, onLogout, sounds
       </div>
       {authenticated && (
         <>
-          <form className="name-form" onSubmit={handleSubmit}>
-            <label>
+          <form id="name-form" className="name-form" onSubmit={handleSubmit}>
+            <label htmlFor="player-name-input" className="player-name-label">
               {t.playerName}
-              <input value={name} onChange={(e) => setName(e.target.value)} />
             </label>
-            <button type="submit" className="main-button">
+            <input
+              id="player-name-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </form>
+          <div className="action-buttons">
+            <button type="submit" form="name-form" className="main-button">
               {t.save}
             </button>
-          </form>
-          <div className="logout-container">
-            <button onClick={onLogout}>{t.logout}</button>
+            <button onClick={onLogout} className="main-button">
+              {t.logout}
+            </button>
           </div>
         </>
       )}

--- a/minesweeper-ui/js/router.js
+++ b/minesweeper-ui/js/router.js
@@ -26,6 +26,7 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         element={
           <SettingsPage
             authenticated={authenticated}
+            keycloak={keycloak}
             onLogout={() =>
               keycloak.logout({
                 redirectUri: window.location.href.split('#')[0] + '#/login',


### PR DESCRIPTION
## Summary
- add REST endpoints to retrieve and update the authenticated player's name
- expose name edit form in settings with translations and styling

## Testing
- `npm test`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689023b1152c832cbd5cbadc3638ee6a