### PR TITLE
feat(api): update player last connection date

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/PlayerLastConnexionFilter.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PlayerLastConnexionFilter.java
@@ -1,0 +1,51 @@
+package com.minesweeper;
+
+import com.minesweeper.entity.Player;
+import com.minesweeper.repository.PlayerRepository;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+/**
+ * Updates the player's last connection date on each authenticated request.
+ */
+@Provider
+@Priority(Priorities.USER)
+public class PlayerLastConnexionFilter implements ContainerRequestFilter {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    PlayerRepository playerRepository;
+
+    @Override
+    @Transactional
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (identity == null || identity.isAnonymous()) {
+            return;
+        }
+
+        String playerId = identity.getPrincipal().getName();
+        LocalDateTime now = LocalDateTime.now();
+        Player player = playerRepository.findById(playerId);
+        if (player == null) {
+            player = new Player();
+            player.setId(playerId);
+            player.setName(playerId);
+            player.setDateLastConnexion(now);
+            playerRepository.persist(player);
+        } else {
+            player.setDateLastConnexion(now);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- update player last connection date on each authenticated API call

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68902a5db268832c8889cf838dbf1581