### PR TITLE
Use Keycloak first name for player name

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/PlayerLastConnexionFilter.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PlayerLastConnexionFilter.java
@@ -44,7 +44,9 @@ public class PlayerLastConnexionFilter implements ContainerRequestFilter {
         if (player == null) {
             player = new Player();
             player.setId(playerId);
-            player.setName(identity.getPrincipal().getName());
+            String firstName = jwt.getClaim("given_name");
+            String defaultName = identity.getPrincipal().getName();
+            player.setName(firstName != null ? firstName : defaultName);
             player.setDateLastConnexion(now);
             playerRepository.persist(player);
         } else {

--- a/minesweeper-api/src/main/java/com/minesweeper/PlayerResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PlayerResource.java
@@ -34,7 +34,8 @@ public class PlayerResource {
         if (player == null) {
             player = new Player();
             player.setId(id);
-            player.setName(id);
+            String firstName = jwt.getClaim("given_name");
+            player.setName(firstName != null ? firstName : id);
             player.setDateLastConnexion(LocalDateTime.now());
             playerRepository.persist(player);
         }
@@ -51,10 +52,14 @@ public class PlayerResource {
         if (player == null) {
             player = new Player();
             player.setId(id);
+            String firstName = jwt.getClaim("given_name");
+            player.setName(firstName != null ? firstName : id);
             player.setDateLastConnexion(LocalDateTime.now());
             playerRepository.persist(player);
         }
-        player.setName(request.name());
+        if (request.name() != null && !request.name().isBlank()) {
+            player.setName(request.name());
+        }
         return new PlayerInfo(player.getId(), player.getName());
     }
 }


### PR DESCRIPTION
## Summary
- Use Keycloak `given_name` claim when creating players in resource and last-connexion filter
- Default to Keycloak first name on update and avoid overriding with blank names

## Testing
- `mvn -q -f minesweeper-api/pom.xml test` *(fails: dependencies.dependency.version for io.quarkus:quarkus-rest:jar is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689031577108832cb86810940f6c3b0d