### PR TITLE
Add player data tracking and info page

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/DailyIncomeScheduler.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/DailyIncomeScheduler.java
@@ -1,0 +1,41 @@
+package com.minesweeper;
+
+import com.minesweeper.entity.Player;
+import com.minesweeper.entity.PlayerData;
+import com.minesweeper.repository.PlayerDataRepository;
+import com.minesweeper.repository.PlayerRepository;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class DailyIncomeScheduler {
+
+    @Inject
+    PlayerRepository playerRepository;
+
+    @Inject
+    PlayerDataRepository playerDataRepository;
+
+    @Scheduled(cron = "0 0 1 * * ?")
+    @Transactional
+    void addDailyIncome() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(72);
+        List<Player> players = playerRepository.list("dateLastConnexion > ?1", threshold);
+        for (Player p : players) {
+            PlayerData data = playerDataRepository.findById(p.getId());
+            if (data == null) {
+                data = new PlayerData();
+                data.setIdPlayer(p.getId());
+                data.setReputation(0);
+                data.setGold(50);
+                data.setScanRangeMax(10);
+                data.setIncomePerDay(50);
+                playerDataRepository.persist(data);
+            }
+            data.setGold(data.getGold() + data.getIncomePerDay());
+        }
+    }
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/PlayerDataResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PlayerDataResource.java
@@ -1,0 +1,84 @@
+package com.minesweeper;
+
+import com.minesweeper.dto.PlayerDataInfo;
+import com.minesweeper.entity.PlayerData;
+import com.minesweeper.repository.PlayerDataRepository;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+@Path("/player-data")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PlayerDataResource {
+
+    @Inject
+    PlayerDataRepository playerDataRepository;
+
+    @Inject
+    JsonWebToken jwt;
+
+    private PlayerData getOrCreate(String id) {
+        PlayerData data = playerDataRepository.findById(id);
+        if (data == null) {
+            data = new PlayerData();
+            data.setIdPlayer(id);
+            data.setReputation(0);
+            data.setGold(50);
+            data.setScanRangeMax(10);
+            data.setIncomePerDay(50);
+            playerDataRepository.persist(data);
+        }
+        return data;
+    }
+
+    @GET
+    @Path("/me")
+    @Authenticated
+    @Transactional
+    public PlayerDataInfo me() {
+        String id = jwt.getSubject();
+        PlayerData data = getOrCreate(id);
+        return new PlayerDataInfo(data.getReputation(), data.getGold(), data.getScanRangeMax(), data.getIncomePerDay());
+        }
+
+    @POST
+    @Path("/me/upgrade-scan")
+    @Authenticated
+    @Transactional
+    public PlayerDataInfo upgradeScan() {
+        String id = jwt.getSubject();
+        PlayerData data = getOrCreate(id);
+        int cost = (int) Math.pow(2, data.getScanRangeMax() - 9);
+        if (data.getGold() < cost) {
+            throw new BadRequestException();
+        }
+        data.setGold(data.getGold() - cost);
+        data.setScanRangeMax(data.getScanRangeMax() + 1);
+        return new PlayerDataInfo(data.getReputation(), data.getGold(), data.getScanRangeMax(), data.getIncomePerDay());
+    }
+
+    @POST
+    @Path("/me/upgrade-income")
+    @Authenticated
+    @Transactional
+    public PlayerDataInfo upgradeIncome() {
+        String id = jwt.getSubject();
+        PlayerData data = getOrCreate(id);
+        int cost = (int) Math.pow(2, (data.getIncomePerDay() - 50) / 10);
+        if (data.getGold() < cost) {
+            throw new BadRequestException();
+        }
+        data.setGold(data.getGold() - cost);
+        data.setIncomePerDay(data.getIncomePerDay() + 10);
+        return new PlayerDataInfo(data.getReputation(), data.getGold(), data.getScanRangeMax(), data.getIncomePerDay());
+    }
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/PlayerDataInfo.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/PlayerDataInfo.java
@@ -1,0 +1,4 @@
+package com.minesweeper.dto;
+
+public record PlayerDataInfo(int reputation, int gold, int scanRangeMax, int incomePerDay) {
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/entity/PlayerData.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/entity/PlayerData.java
@@ -1,0 +1,68 @@
+package com.minesweeper.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "player_data")
+public class PlayerData {
+
+    @Id
+    @Column(name = "id_player")
+    private String idPlayer;
+
+    @Column(name = "reputation", nullable = false)
+    private int reputation;
+
+    @Column(name = "gold", nullable = false)
+    private int gold;
+
+    @Column(name = "scan_range_max", nullable = false)
+    private int scanRangeMax;
+
+    @Column(name = "income_per_day", nullable = false)
+    private int incomePerDay;
+
+    public String getIdPlayer() {
+        return idPlayer;
+    }
+
+    public void setIdPlayer(String idPlayer) {
+        this.idPlayer = idPlayer;
+    }
+
+    public int getReputation() {
+        return reputation;
+    }
+
+    public void setReputation(int reputation) {
+        this.reputation = reputation;
+    }
+
+    public int getGold() {
+        return gold;
+    }
+
+    public void setGold(int gold) {
+        this.gold = gold;
+    }
+
+    public int getScanRangeMax() {
+        return scanRangeMax;
+    }
+
+    public void setScanRangeMax(int scanRangeMax) {
+        this.scanRangeMax = scanRangeMax;
+    }
+
+    public int getIncomePerDay() {
+        return incomePerDay;
+    }
+
+    public void setIncomePerDay(int incomePerDay) {
+        this.incomePerDay = incomePerDay;
+    }
+}
+

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerDataRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/PlayerDataRepository.java
@@ -1,0 +1,9 @@
+package com.minesweeper.repository;
+
+import com.minesweeper.entity.PlayerData;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PlayerDataRepository implements PanacheRepositoryBase<PlayerData, String> {
+}

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -41,14 +41,20 @@ h1 {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
+  width: 80%;
   text-align: left;
-  font-size: 10vh;
+  font-size: 12vh;
   padding: 0.25rem 0;
   z-index: 30;
   pointer-events: auto;
-  white-space: pre;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   cursor: pointer;
+  color: #fff;
+  -webkit-text-stroke: 1px #333;
+  text-shadow: -1px -1px 0 #333, 1px -1px 0 #333, -1px 1px 0 #333, 1px 1px 0 #333;
+  display: inline-block;
 }
 
 .games-list-button {

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -36,6 +36,30 @@ h1 {
   z-index: 10;
 }
 
+.stats-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  font-size: 2rem;
+  padding: 0.25rem 0;
+  z-index: 30;
+  pointer-events: none;
+  white-space: pre;
+}
+
+.games-list-button {
+  position: fixed;
+  bottom: 0.5rem;
+  left: 0.5rem;
+  font-size: 4rem;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 10;
+}
+
 .settings-page,
 .login-page,
 .no-games,
@@ -318,4 +342,14 @@ button:active {
 .name-form input {
   font-size: 1.5rem;
   padding: 0.5rem;
+}
+
+@media screen and (orientation:portrait) {
+  body {
+    transform: rotate(90deg);
+    transform-origin: left top;
+    width: 100vh;
+    height: 100vw;
+    overflow: hidden;
+  }
 }

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -19,6 +19,7 @@ body {
   font-family: "Mouse Memoirs", sans-serif;
   background-color: #000;
   color: #fff;
+  font-size: 10vh;
 }
 
 h1 {
@@ -29,7 +30,7 @@ h1 {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
-  font-size: 4rem;
+  font-size: 12vh;
   color: inherit;
   text-decoration: none;
   cursor: pointer;
@@ -41,19 +42,20 @@ h1 {
   top: 0;
   left: 0;
   width: 100%;
-  text-align: center;
-  font-size: 2rem;
+  text-align: left;
+  font-size: 10vh;
   padding: 0.25rem 0;
   z-index: 30;
-  pointer-events: none;
+  pointer-events: auto;
   white-space: pre;
+  cursor: pointer;
 }
 
 .games-list-button {
   position: fixed;
   bottom: 0.5rem;
   left: 0.5rem;
-  font-size: 4rem;
+  font-size: 12vh;
   color: inherit;
   text-decoration: none;
   cursor: pointer;
@@ -88,7 +90,7 @@ h1 {
 .flag-button {
   background: none;
   border: none;
-  font-size: 4rem;
+  font-size: 12vh;
   opacity: 0.5;
 }
 
@@ -122,7 +124,7 @@ button:active {
 
 .login-page button,
 .main-button {
-  font-size: 2rem;
+  font-size: 12vh;
   padding: 1rem 2rem;
   color: #fff;
   -webkit-text-stroke: 1px #333;
@@ -158,7 +160,7 @@ button:active {
 }
 
 .modal input {
-  font-size: 1rem;
+  font-size: 10vh;
   padding: 0.5rem;
   width: 100%;
   box-sizing: border-box;
@@ -185,7 +187,7 @@ button:active {
   justify-content: center;
   background: #000;
   color: #fff;
-  font-size: 2rem;
+  font-size: 10vh;
 }
 
 .sound-toggle-container {
@@ -195,7 +197,7 @@ button:active {
 }
 
 .sound-toggle {
-  font-size: 3rem;
+  font-size: 12vh;
   color: inherit;
 }
 
@@ -206,7 +208,7 @@ button:active {
 }
 
 .player-name-label {
-  font-size: 2rem;
+  font-size: 10vh;
 }
 
 .action-buttons {
@@ -237,7 +239,7 @@ button:active {
 }
 
 .no-games p {
-  font-size: 2rem;
+  font-size: 10vh;
   margin: 2rem 0;
 }
 
@@ -282,7 +284,7 @@ button:active {
   text-decoration: none;
   white-space: nowrap;
   max-width: 90vw;
-  font-size: 2rem;
+  font-size: 10vh;
 }
 
 .game-prefix,
@@ -340,7 +342,7 @@ button:active {
 }
 
 .name-form input {
-  font-size: 1.5rem;
+  font-size: 10vh;
   padding: 0.5rem;
 }
 

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -19,7 +19,7 @@ body {
   font-family: "Mouse Memoirs", sans-serif;
   background-color: #000;
   color: #fff;
-  font-size: 10vh;
+  font-size: 8vh;
 }
 
 h1 {
@@ -30,7 +30,7 @@ h1 {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
-  font-size: 12vh;
+  font-size: 10vh;
   color: inherit;
   text-decoration: none;
   cursor: pointer;
@@ -43,7 +43,7 @@ h1 {
   left: 0;
   width: 80%;
   text-align: left;
-  font-size: 12vh;
+  font-size: 10vh;
   padding: 0.25rem 0;
   z-index: 30;
   pointer-events: auto;
@@ -61,7 +61,7 @@ h1 {
   position: fixed;
   bottom: 0.5rem;
   left: 0.5rem;
-  font-size: 12vh;
+  font-size: 10vh;
   color: inherit;
   text-decoration: none;
   cursor: pointer;
@@ -96,7 +96,7 @@ h1 {
 .flag-button {
   background: none;
   border: none;
-  font-size: 12vh;
+  font-size: 10vh;
   opacity: 0.5;
 }
 
@@ -130,11 +130,12 @@ button:active {
 
 .login-page button,
 .main-button {
-  font-size: 12vh;
+  font-size: 10vh;
   padding: 1rem 2rem;
   color: #fff;
   -webkit-text-stroke: 1px #333;
   text-shadow: -1px -1px 0 #333, 1px -1px 0 #333, -1px 1px 0 #333, 1px 1px 0 #333;
+  text-decoration: none;
 }
 
 .modal-overlay {
@@ -166,7 +167,7 @@ button:active {
 }
 
 .modal input {
-  font-size: 10vh;
+  font-size: 8vh;
   padding: 0.5rem;
   width: 100%;
   box-sizing: border-box;
@@ -193,18 +194,19 @@ button:active {
   justify-content: center;
   background: #000;
   color: #fff;
-  font-size: 10vh;
+  font-size: 8vh;
 }
 
 .sound-toggle-container {
   position: absolute;
-  top: 5rem;
+  bottom: 0.5rem;
   right: 0.5rem;
 }
 
 .sound-toggle {
-  font-size: 12vh;
+  font-size: 10vh;
   color: inherit;
+  text-decoration: none;
 }
 
 .name-form {
@@ -214,7 +216,7 @@ button:active {
 }
 
 .player-name-label {
-  font-size: 10vh;
+  font-size: 8vh;
 }
 
 .action-buttons {
@@ -245,7 +247,7 @@ button:active {
 }
 
 .no-games p {
-  font-size: 10vh;
+  font-size: 8vh;
   margin: 2rem 0;
 }
 
@@ -348,16 +350,47 @@ button:active {
 }
 
 .name-form input {
-  font-size: 10vh;
+  font-size: 8vh;
   padding: 0.5rem;
+  width: 50%;
 }
 
 @media screen and (orientation:portrait) {
-  body {
+body {
     transform: rotate(90deg);
     transform-origin: left top;
     width: 100vh;
     height: 100vw;
     overflow: hidden;
   }
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.info-page {
+  position: relative;
+  height: 100vh;
+  text-align: center;
+}
+
+.income-line {
+  margin-top: 15vh;
+}
+
+.upgrade-row {
+  display: flex;
+  width: 100%;
+  margin-top: 5vh;
+}
+
+.upgrade-block {
+  width: 50%;
+  text-align: center;
+}
+
+.upgrade-cost {
+  margin-top: 1vh;
 }

--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -145,8 +145,8 @@ function GamesListButton() {
 
 function StatsBar({ data }) {
   return (
-    <div className="stats-bar">
+    <Link to="/info" className="stats-bar">
       {`Gold: ${data.gold} po    scan: ${data.scanRangeMax}    reputation: ${data.reputation}`}
-    </div>
+    </Link>
   );
 }

--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -43,22 +43,22 @@ export default function App() {
   }, [soundsOn]);
 
   React.useEffect(() => {
-    const handleOrientationChange = () => {
-      const isLandscape = window.innerWidth > window.innerHeight;
+    const lockLandscape = () => {
       const elem = document.documentElement;
-      if (isLandscape) {
-        if (!document.fullscreenElement && elem.requestFullscreen) {
-          elem.requestFullscreen().catch(() => {});
-        }
-      } else if (document.fullscreenElement && document.exitFullscreen) {
-        document.exitFullscreen().catch(() => {});
+      if (!document.fullscreenElement && elem.requestFullscreen) {
+        elem.requestFullscreen().catch(() => {});
+      }
+      if (screen.orientation && screen.orientation.lock) {
+        screen.orientation.lock('landscape').catch(() => {});
       }
     };
 
-    window.addEventListener('resize', handleOrientationChange);
-    handleOrientationChange();
+    window.addEventListener('orientationchange', lockLandscape);
+    window.addEventListener('resize', lockLandscape);
+    lockLandscape();
     return () => {
-      window.removeEventListener('resize', handleOrientationChange);
+      window.removeEventListener('orientationchange', lockLandscape);
+      window.removeEventListener('resize', lockLandscape);
     };
   }, []);
 
@@ -90,6 +90,7 @@ export default function App() {
       <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         {authenticated && playerData && <StatsBar data={playerData} />}
         <SettingsButton />
+        <GamesListButton />
         <AppRouter
           authenticated={authenticated}
           keycloak={keycloak}
@@ -126,6 +127,18 @@ function SettingsButton() {
       aria-label="Settings"
     >
       <i className="fa-solid fa-gear"></i>
+    </Link>
+  );
+}
+
+function GamesListButton() {
+  const location = useLocation();
+  if (location.pathname === '/games') {
+    return null;
+  }
+  return (
+    <Link to="/games" className="games-list-button" aria-label="Games">
+      <i className="fa-solid fa-table"></i>
     </Link>
   );
 }

--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -62,10 +62,6 @@ export default function App() {
     };
   }, []);
 
-  if (!keycloak) {
-    return null;
-  }
-
   const toggleSounds = () => setSoundsOn((s) => !s);
   const login = () => keycloak.login({ idpHint: 'google' });
 
@@ -84,6 +80,10 @@ export default function App() {
       fetchPlayerData();
     }
   }, [authenticated, fetchPlayerData]);
+
+  if (!keycloak) {
+    return null;
+  }
 
   return (
     <LangProvider>

--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -146,7 +146,7 @@ function GamesListButton() {
 function StatsBar({ data }) {
   return (
     <Link to="/info" className="stats-bar">
-      {`Gold: ${data.gold} po    scan: ${data.scanRangeMax}    reputation: ${data.reputation}`}
+      {`Gold: ${data.gold} po | scan: ${data.scanRangeMax} | reputation: ${data.reputation}`}
     </Link>
   );
 }

--- a/minesweeper-ui/js/locales/en.js
+++ b/minesweeper-ui/js/locales/en.js
@@ -28,6 +28,5 @@ export default {
   "dailyIncome": "Daily income",
   "upgradeScan": "Upgrade scan range",
   "upgradeIncome": "Upgrade daily income",
-  "cost": "Cost",
-  "info": "Info"
+  "cost": "Cost"
 };

--- a/minesweeper-ui/js/locales/en.js
+++ b/minesweeper-ui/js/locales/en.js
@@ -22,5 +22,12 @@ export default {
   "scan": "Scan",
   "rescan": "Rescan",
   "demine": "Clear",
-  "status": "Status"
+  "status": "Status",
+  "gold": "Gold",
+  "reputation": "Reputation",
+  "dailyIncome": "Daily income",
+  "upgradeScan": "Upgrade scan range",
+  "upgradeIncome": "Upgrade daily income",
+  "cost": "Cost",
+  "info": "Info"
 };

--- a/minesweeper-ui/js/locales/fr.js
+++ b/minesweeper-ui/js/locales/fr.js
@@ -28,6 +28,5 @@ export default {
   "dailyIncome": "Salaire journalier",
   "upgradeScan": "Am\u00E9liorer la port\u00E9e du scan",
   "upgradeIncome": "Am\u00E9liorer le salaire",
-  "cost": "Co\u00FBt",
-  "info": "Infos"
+  "cost": "Co\u00FBt"
 };

--- a/minesweeper-ui/js/locales/fr.js
+++ b/minesweeper-ui/js/locales/fr.js
@@ -22,5 +22,12 @@ export default {
   "scan": "Scanner",
   "rescan": "Re-scanner",
   "demine": "D\u00E9miner",
-  "status": "Statut"
+  "status": "Statut",
+  "gold": "Or",
+  "reputation": "R\u00E9putation",
+  "dailyIncome": "Salaire journalier",
+  "upgradeScan": "Am\u00E9liorer la port\u00E9e du scan",
+  "upgradeIncome": "Am\u00E9liorer le salaire",
+  "cost": "Co\u00FBt",
+  "info": "Infos"
 };

--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -1,7 +1,7 @@
 const { useParams } = ReactRouterDOM;
 import { LangContext } from '../i18n.js';
 
-export default function GamePage({ keycloak }) {
+export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
   const { id } = useParams();
   const { t } = React.useContext(LangContext);
   const canvasRef = React.useRef(null);
@@ -33,6 +33,12 @@ export default function GamePage({ keycloak }) {
         }
       });
   }, [apiUrl, id, keycloak]);
+
+  React.useEffect(() => {
+    if (playerData && scanRange > playerData.scanRangeMax) {
+      setScanRange(playerData.scanRangeMax);
+    }
+  }, [playerData, scanRange]);
 
   React.useEffect(() => {
     if (!game) return;
@@ -410,6 +416,7 @@ export default function GamePage({ keycloak }) {
           setScanRange(Math.max(res.scanRange ?? 2, 2));
         }
         requestAnimationFrame(draw);
+        refreshPlayerData && refreshPlayerData();
       });
   };
 
@@ -460,6 +467,7 @@ export default function GamePage({ keycloak }) {
             mine: res,
           }));
         }
+        refreshPlayerData && refreshPlayerData();
       });
   };
 
@@ -487,7 +495,7 @@ export default function GamePage({ keycloak }) {
                 <input
                   type="range"
                   min="2"
-                  max="10"
+                  max={playerData?.scanRangeMax ?? 10}
                   value={scanRange ?? 2}
                   onChange={(e) => setScanRange(Number(e.target.value))}
                 />
@@ -495,7 +503,7 @@ export default function GamePage({ keycloak }) {
               {selected.scan && (
                 <p>{t.scanResult}: {selected.scan.mineCount}</p>
               )}
-              <button className="main-button" onClick={handleScan}>
+              <button className="main-button" onClick={handleScan} disabled={playerData?.gold <= 0}>
                 {selected.scan ? t.rescan : t.scan}
               </button>
               {!selected.scan && (

--- a/minesweeper-ui/js/pages/GamesListPage.js
+++ b/minesweeper-ui/js/pages/GamesListPage.js
@@ -30,6 +30,9 @@ export default function GamesListPage({ keycloak }) {
 
   return (
     <div>
+      <Link to="/info" className="main-button">
+        {t.info}
+      </Link>
       {games.length === 0 ? (
         <div className="no-games">
           <div className="no-games-message">

--- a/minesweeper-ui/js/pages/GamesListPage.js
+++ b/minesweeper-ui/js/pages/GamesListPage.js
@@ -30,9 +30,6 @@ export default function GamesListPage({ keycloak }) {
 
   return (
     <div>
-      <Link to="/info" className="main-button">
-        {t.info}
-      </Link>
       {games.length === 0 ? (
         <div className="no-games">
           <div className="no-games-message">

--- a/minesweeper-ui/js/pages/InfoPage.js
+++ b/minesweeper-ui/js/pages/InfoPage.js
@@ -1,0 +1,53 @@
+import { LangContext } from '../i18n.js';
+
+export default function InfoPage({ keycloak, playerData, refreshPlayerData }) {
+  const { t } = React.useContext(LangContext);
+  const apiUrl = window.CONFIG['minesweeper-api-url'];
+
+  if (!playerData) return null;
+
+  const upgradeScan = () => {
+    fetch(`${apiUrl}/player-data/me/upgrade-scan`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${keycloak.token}` },
+    })
+      .then((r) => r.json())
+      .then(() => refreshPlayerData());
+  };
+
+  const upgradeIncome = () => {
+    fetch(`${apiUrl}/player-data/me/upgrade-income`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${keycloak.token}` },
+    })
+      .then((r) => r.json())
+      .then(() => refreshPlayerData());
+  };
+
+  const scanCost = Math.pow(2, playerData.scanRangeMax - 9);
+  const incomeCost = Math.pow(2, (playerData.incomePerDay - 50) / 10);
+
+  return (
+    <div className="info-page">
+      <p>
+        {t.dailyIncome}: {playerData.incomePerDay} {t.gold}
+      </p>
+      <div className="upgrade-block">
+        <button className="main-button" onClick={upgradeScan}>
+          {t.upgradeScan}
+        </button>
+        <p>
+          {t.cost}: {scanCost}
+        </p>
+      </div>
+      <div className="upgrade-block">
+        <button className="main-button" onClick={upgradeIncome}>
+          {t.upgradeIncome}
+        </button>
+        <p>
+          {t.cost}: {incomeCost}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/minesweeper-ui/js/pages/InfoPage.js
+++ b/minesweeper-ui/js/pages/InfoPage.js
@@ -29,24 +29,26 @@ export default function InfoPage({ keycloak, playerData, refreshPlayerData }) {
 
   return (
     <div className="info-page">
-      <p>
+      <div className="income-line">
         {t.dailyIncome}: {playerData.incomePerDay} {t.gold}
-      </p>
-      <div className="upgrade-block">
-        <button className="main-button" onClick={upgradeScan}>
-          {t.upgradeScan}
-        </button>
-        <p>
-          {t.cost}: {scanCost}
-        </p>
       </div>
-      <div className="upgrade-block">
-        <button className="main-button" onClick={upgradeIncome}>
-          {t.upgradeIncome}
-        </button>
-        <p>
-          {t.cost}: {incomeCost}
-        </p>
+      <div className="upgrade-row">
+        <div className="upgrade-block">
+          <button className="main-button" onClick={upgradeScan}>
+            {t.upgradeScan}
+          </button>
+          <div className="upgrade-cost">
+            {t.cost}: {scanCost}
+          </div>
+        </div>
+        <div className="upgrade-block">
+          <button className="main-button" onClick={upgradeIncome}>
+            {t.upgradeIncome}
+          </button>
+          <div className="upgrade-cost">
+            {t.cost}: {incomeCost}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/minesweeper-ui/js/router.js
+++ b/minesweeper-ui/js/router.js
@@ -3,8 +3,9 @@ import LoginPage from './pages/LoginPage.js';
 import GamesListPage from './pages/GamesListPage.js';
 import GamePage from './pages/GamePage.js';
 import SettingsPage from './pages/SettingsPage.js';
+import InfoPage from './pages/InfoPage.js';
 
-export default function AppRouter({ authenticated, keycloak, login, soundsOn, toggleSounds }) {
+export default function AppRouter({ authenticated, keycloak, login, soundsOn, toggleSounds, playerData, refreshPlayerData }) {
   const RequireAuth = ({ children }) =>
     authenticated ? children : <Navigate to="/login" />;
 
@@ -49,7 +50,15 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         path="/games/:id"
         element={
           <RequireAuth>
-            <GamePage keycloak={keycloak} />
+            <GamePage keycloak={keycloak} playerData={playerData} refreshPlayerData={refreshPlayerData} />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/info"
+        element={
+          <RequireAuth>
+            <InfoPage keycloak={keycloak} playerData={playerData} refreshPlayerData={refreshPlayerData} />
           </RequireAuth>
         }
       />


### PR DESCRIPTION
## Summary
- track player stats like gold, reputation, scan range, and income
- enable scans and mines to update player gold and reputation with costs and rewards
- show player stats with an info page for upgrades and a daily income scheduler

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689033dca194832cb1a8402afe0c4569