### PR TITLE
Add leaderboard and new game controls

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/LeaderboardResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/LeaderboardResource.java
@@ -1,0 +1,75 @@
+package com.minesweeper;
+
+import com.minesweeper.dto.LeaderboardInfo;
+import com.minesweeper.entity.ActionEvent;
+import com.minesweeper.repository.ActionEventRepository;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import java.time.*;
+import java.util.*;
+
+@Path("/leaderboard")
+@Produces(MediaType.APPLICATION_JSON)
+public class LeaderboardResource {
+
+    @Inject
+    ActionEventRepository actionEventRepository;
+
+    @GET
+    @Path("/{period}")
+    @Authenticated
+    public List<LeaderboardInfo> getLeaderboard(@PathParam("period") String period) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime start;
+        switch (period.toLowerCase()) {
+            case "daily" -> {
+                LocalDate today = now.toLocalDate();
+                start = LocalDateTime.of(today, LocalTime.of(1, 0));
+                if (now.isBefore(start)) {
+                    start = start.minusDays(1);
+                }
+            }
+            case "weekly" -> {
+                LocalDate date = now.toLocalDate();
+                LocalDate monday = date.with(java.time.DayOfWeek.MONDAY);
+                start = LocalDateTime.of(monday, LocalTime.of(1, 0));
+                if (now.isBefore(start)) {
+                    start = start.minusWeeks(1);
+                }
+            }
+            case "monthly" -> {
+                LocalDate first = now.toLocalDate().withDayOfMonth(1);
+                start = LocalDateTime.of(first, LocalTime.of(1, 0));
+                if (now.isBefore(start)) {
+                    start = start.minusMonths(1);
+                }
+            }
+            default -> throw new BadRequestException();
+        }
+        LocalDateTime end;
+        switch (period.toLowerCase()) {
+            case "daily" -> end = start.plusDays(1);
+            case "weekly" -> end = start.plusWeeks(1);
+            case "monthly" -> end = start.plusMonths(1);
+            default -> throw new BadRequestException();
+        }
+        List<ActionEvent> events = actionEventRepository.list("eventDate >= ?1 and eventDate < ?2", start, end);
+        Map<String, Integer> points = new HashMap<>();
+        for (ActionEvent e : events) {
+            int delta = switch (e.getEventType()) {
+                case "SCAN_NOTHING" -> 1;
+                case "SCAN_MINEDETECTED" -> 5;
+                case "EXPLOSION" -> -5;
+                case "DEFUSED" -> 10;
+                default -> 0;
+            };
+            points.merge(e.getPlayer().getId(), delta, Integer::sum);
+        }
+        return points.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .map(e -> new LeaderboardInfo(e.getKey(), e.getValue()))
+                .toList();
+    }
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/MineResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/MineResource.java
@@ -12,6 +12,8 @@ import com.minesweeper.repository.MineRepository;
 import com.minesweeper.repository.PlayerRepository;
 import com.minesweeper.repository.PlayerScanRepository;
 import com.minesweeper.repository.PlayerDataRepository;
+import com.minesweeper.repository.ActionEventRepository;
+import com.minesweeper.entity.ActionEvent;
 import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -41,6 +43,9 @@ public class MineResource {
 
     @Inject
     PlayerDataRepository playerDataRepository;
+
+    @Inject
+    ActionEventRepository actionEventRepository;
 
     @GET
     @Path("/cleared")
@@ -90,6 +95,13 @@ public class MineResource {
             mine.setExploded(false);
             data.setGold(data.getGold() + 1000);
             data.setReputation(data.getReputation() + 1);
+            ActionEvent event = new ActionEvent();
+            event.setId(UUID.randomUUID().toString());
+            event.setPlayer(player);
+            event.setGame(game);
+            event.setEventType("DEFUSED");
+            event.setEventDate(LocalDateTime.now());
+            actionEventRepository.persist(event);
             return new MineInfo(mine.getId(), mine.getX(), mine.getY(), "cleared");
         }
 
@@ -107,6 +119,13 @@ public class MineResource {
         if (exploded != null && Boolean.TRUE.equals(exploded.getExploded())) {
             data.setGold(Math.max(0, data.getGold() - 500));
             data.setReputation(Math.max(0, data.getReputation() - 10));
+            ActionEvent event = new ActionEvent();
+            event.setId(UUID.randomUUID().toString());
+            event.setPlayer(player);
+            event.setGame(game);
+            event.setEventType("EXPLOSION");
+            event.setEventDate(LocalDateTime.now());
+            actionEventRepository.persist(event);
             return new MineInfo(exploded.getId(), exploded.getX(), exploded.getY(), "explosed");
         }
         return new MineInfo(null, request.x(), request.y(), "wrong");

--- a/minesweeper-api/src/main/java/com/minesweeper/PlayerDataResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PlayerDataResource.java
@@ -1,6 +1,7 @@
 package com.minesweeper;
 
 import com.minesweeper.dto.PlayerDataInfo;
+import com.minesweeper.dto.AddGoldRequest;
 import com.minesweeper.entity.PlayerData;
 import com.minesweeper.repository.PlayerDataRepository;
 import io.quarkus.security.Authenticated;
@@ -79,6 +80,17 @@ public class PlayerDataResource {
         }
         data.setGold(data.getGold() - cost);
         data.setIncomePerDay(data.getIncomePerDay() + 10);
+        return new PlayerDataInfo(data.getReputation(), data.getGold(), data.getScanRangeMax(), data.getIncomePerDay());
+    }
+
+    @POST
+    @Path("/me/add-gold")
+    @Authenticated
+    @Transactional
+    public PlayerDataInfo addGold(AddGoldRequest request) {
+        String id = jwt.getSubject();
+        PlayerData data = getOrCreate(id);
+        data.setGold(data.getGold() + Math.max(0, request.amount()));
         return new PlayerDataInfo(data.getReputation(), data.getGold(), data.getScanRangeMax(), data.getIncomePerDay());
     }
 }

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/AddGoldRequest.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/AddGoldRequest.java
@@ -1,0 +1,3 @@
+package com.minesweeper.dto;
+
+public record AddGoldRequest(int amount) {}

--- a/minesweeper-api/src/main/java/com/minesweeper/dto/LeaderboardInfo.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/dto/LeaderboardInfo.java
@@ -1,0 +1,3 @@
+package com.minesweeper.dto;
+
+public record LeaderboardInfo(String playerId, int points) {}

--- a/minesweeper-api/src/main/java/com/minesweeper/entity/ActionEvent.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/entity/ActionEvent.java
@@ -1,0 +1,42 @@
+package com.minesweeper.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "actionevent")
+public class ActionEvent {
+
+    @Id
+    @Column(name = "id_actionevent")
+    private String id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "id_player")
+    private Player player;
+
+    @ManyToOne
+    @JoinColumn(name = "id_game")
+    private Game game;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(name = "event_date", nullable = false)
+    private LocalDateTime eventDate;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public Player getPlayer() { return player; }
+    public void setPlayer(Player player) { this.player = player; }
+
+    public Game getGame() { return game; }
+    public void setGame(Game game) { this.game = game; }
+
+    public String getEventType() { return eventType; }
+    public void setEventType(String eventType) { this.eventType = eventType; }
+
+    public LocalDateTime getEventDate() { return eventDate; }
+    public void setEventDate(LocalDateTime eventDate) { this.eventDate = eventDate; }
+}

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/ActionEventRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/ActionEventRepository.java
@@ -1,0 +1,9 @@
+package com.minesweeper.repository;
+
+import com.minesweeper.entity.ActionEvent;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ActionEventRepository implements PanacheRepositoryBase<ActionEvent, String> {
+}

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -68,12 +68,58 @@ h1 {
 
 .games-list-button {
   position: fixed;
-  bottom: 0.5rem;
-  left: 0.5rem;
+  top: 6rem;
+  right: 0.5rem;
   font-size: 10vh;
   color: inherit;
   text-decoration: none;
   cursor: pointer;
+  z-index: 10;
+}
+
+.leaderboard-button {
+  position: fixed;
+  top: 12rem;
+  right: 0.5rem;
+  font-size: 10vh;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.boost-button {
+  position: fixed;
+  top: 18rem;
+  right: 0.5rem;
+  font-size: 10vh;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.show-zones-button {
+  position: fixed;
+  bottom: 6rem;
+  left: 0.5rem;
+  font-size: 10vh;
+  z-index: 10;
+}
+
+.hide-zones-button {
+  position: fixed;
+  bottom: 0.5rem;
+  left: 0.5rem;
+  font-size: 10vh;
+  z-index: 10;
+}
+
+.refresh-button {
+  position: fixed;
+  bottom: 12rem;
+  left: 0.5rem;
+  font-size: 10vh;
   z-index: 10;
 }
 
@@ -86,6 +132,37 @@ h1 {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+}
+
+.leaderboard-page {
+  text-align: center;
+  padding-top: 8rem;
+}
+
+.leaderboard-tabs button.active {
+  font-weight: bold;
+}
+
+.leaderboard-list {
+  list-style: none;
+  padding: 0;
+}
+
+.boost-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.boost-container {
+  display: flex;
+  gap: 2rem;
+}
+
+.boost-item {
+  text-align: center;
+  cursor: pointer;
 }
 
 .settings-page {

--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -91,6 +91,8 @@ export default function App() {
         {authenticated && playerData && <StatsBar data={playerData} />}
         <SettingsButton />
         <GamesListButton />
+        <LeaderboardButton />
+        <BoostButton />
         <AppRouter
           authenticated={authenticated}
           keycloak={keycloak}
@@ -149,6 +151,38 @@ function GamesListButton() {
       <img
         src="images/icons/actions/icon_contracts.png"
         alt="Games"
+        className="icon"
+      />
+    </Link>
+  );
+}
+
+function LeaderboardButton() {
+  const location = useLocation();
+  if (location.pathname === '/leaderboard') {
+    return null;
+  }
+  return (
+    <Link to="/leaderboard" className="leaderboard-button" aria-label="Leaderboard">
+      <img
+        src="images/icons/actions/icon_trophy_loser.png"
+        alt="Leaderboard"
+        className="icon"
+      />
+    </Link>
+  );
+}
+
+function BoostButton() {
+  const location = useLocation();
+  if (location.pathname === '/boost') {
+    return null;
+  }
+  return (
+    <Link to="/boost" className="boost-button" aria-label="Boost">
+      <img
+        src="images/icons/actions/icon_boost.png"
+        alt="Boost"
         className="icon"
       />
     </Link>

--- a/minesweeper-ui/js/pages/BoostPage.js
+++ b/minesweeper-ui/js/pages/BoostPage.js
@@ -1,0 +1,31 @@
+export default function BoostPage({ keycloak, refreshPlayerData }) {
+  const apiUrl = window.CONFIG['minesweeper-api-url'];
+  const buy = (amount) => {
+    fetch(`${apiUrl}/player-data/me/add-gold`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${keycloak.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ amount }),
+    }).then(() => refreshPlayerData());
+  };
+  const items = [
+    { icon: 'icon_buy_small.png', gold: 1000, price: '1.99€' },
+    { icon: 'icon_buy_medium.png', gold: 5000, price: '4.99€' },
+    { icon: 'icon_buy_large.png', gold: 10000, price: '9.99€' },
+  ];
+  return (
+    <div className="boost-page">
+      <div className="boost-container">
+        {items.map((it) => (
+          <div key={it.gold} className="boost-item" onClick={() => buy(it.gold)}>
+            <img src={`images/icons/actions/${it.icon}`} alt="buy" className="icon" />
+            <div>+{it.gold}po</div>
+            <div>{it.price}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -70,8 +70,7 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
     }
   }, [game, id]);
 
-  React.useEffect(() => {
-    if (!game) return;
+  const refreshBoard = React.useCallback(() => {
     fetch(`${apiUrl}/scans/${id}`, {
       headers: { Authorization: `Bearer ${keycloak.token}` },
     })
@@ -84,7 +83,12 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
       .then((r) => r.json())
       .then(setMines)
       .catch(() => setMines([]));
-  }, [apiUrl, id, keycloak, game]);
+  }, [apiUrl, id, keycloak]);
+
+  React.useEffect(() => {
+    if (!game) return;
+    refreshBoard();
+  }, [apiUrl, id, keycloak, game, refreshBoard]);
 
   React.useEffect(() => {
     zoomRef.current = zoom;
@@ -530,6 +534,18 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
         className="game-canvas"
         onPointerDown={handlePointerDown}
       ></canvas>
+      <button
+        className="show-zones-button"
+        onClick={() => setVisibleScans(new Set(scans.map((s) => `${s.x},${s.y}`)))}
+      >
+        <img src="images/icons/actions/icon_eyes_open.png" alt="show" className="icon" />
+      </button>
+      <button className="hide-zones-button" onClick={() => setVisibleScans(new Set())}>
+        <img src="images/icons/actions/icon_eyes_close.png" alt="hide" className="icon" />
+      </button>
+      <button className="refresh-button" onClick={refreshBoard}>
+        <img src="images/icons/actions/icon_refresh.png" alt="refresh" className="icon" />
+      </button>
       {selected && (
         <div className="info-panel">
           <span>({selected.x}, {selected.y})</span>

--- a/minesweeper-ui/js/pages/LeaderboardPage.js
+++ b/minesweeper-ui/js/pages/LeaderboardPage.js
@@ -1,0 +1,59 @@
+const { useState, useEffect } = React;
+import { LangContext } from '../i18n.js';
+
+export default function LeaderboardPage({ keycloak }) {
+  const { t } = React.useContext(LangContext);
+  const [period, setPeriod] = useState('daily');
+  const [data, setData] = useState([]);
+  const apiUrl = window.CONFIG['minesweeper-api-url'];
+
+  const load = React.useCallback(() => {
+    fetch(`${apiUrl}/leaderboard/${period}`, {
+      headers: { Authorization: `Bearer ${keycloak.token}` },
+    })
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => setData([]));
+  }, [apiUrl, period, keycloak]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const renderIcon = (index) => {
+    if (index === 0) return 'icon_trophy_top1.png';
+    if (index === 1) return 'icon_trophy_top2.png';
+    if (index === 2) return 'icon_trophy_top3.png';
+    return null;
+  };
+
+  return (
+    <div className="leaderboard-page">
+      <div className="leaderboard-tabs">
+        {['daily', 'weekly', 'monthly'].map((p) => (
+          <button
+            key={p}
+            className={period === p ? 'active' : ''}
+            onClick={() => setPeriod(p)}
+          >
+            {p.charAt(0).toUpperCase() + p.slice(1)}
+          </button>
+        ))}
+      </div>
+      <ul className="leaderboard-list">
+        {data.map((row, i) => (
+          <li key={row.playerId}>
+            {renderIcon(i) && (
+              <img
+                src={`images/icons/actions/${renderIcon(i)}`}
+                alt="rank"
+                className="icon"
+              />
+            )}
+            {row.playerId}: {row.points}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/minesweeper-ui/js/router.js
+++ b/minesweeper-ui/js/router.js
@@ -4,6 +4,8 @@ import GamesListPage from './pages/GamesListPage.js';
 import GamePage from './pages/GamePage.js';
 import SettingsPage from './pages/SettingsPage.js';
 import InfoPage from './pages/InfoPage.js';
+import LeaderboardPage from './pages/LeaderboardPage.js';
+import BoostPage from './pages/BoostPage.js';
 
 export default function AppRouter({ authenticated, keycloak, login, soundsOn, toggleSounds, playerData, refreshPlayerData }) {
   const RequireAuth = ({ children }) =>
@@ -59,6 +61,22 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         element={
           <RequireAuth>
             <InfoPage keycloak={keycloak} playerData={playerData} refreshPlayerData={refreshPlayerData} />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/leaderboard"
+        element={
+          <RequireAuth>
+            <LeaderboardPage keycloak={keycloak} />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/boost"
+        element={
+          <RequireAuth>
+            <BoostPage keycloak={keycloak} refreshPlayerData={refreshPlayerData} />
           </RequireAuth>
         }
       />


### PR DESCRIPTION
## Summary
- log player actions in new `actionevent` table and expose leaderboard API
- add leaderboard and boost screens with navigation buttons
- provide controls on game board to show/hide scan areas and refresh map

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891713a63f0832c97546ce94c95e8f2