### PR TITLE
Add scan feedback effects and orientation overlay

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -144,6 +144,7 @@ h1 {
 .leaderboard-page {
   text-align: center;
   padding-top: 30vh;
+  min-height: 100vh;
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -544,10 +545,8 @@ a {
 
 .ephemeral-icon {
   position: fixed;
-  top: 50%;
-  left: 50%;
   transform: translate(-50%, -50%);
-  animation: fade 3s forwards;
+  animation: fade 5s forwards;
   pointer-events: none;
   z-index: 200;
 }

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -144,6 +144,11 @@ h1 {
 .leaderboard-page {
   text-align: center;
   padding-top: 30vh;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+    url("../images/images_background_leaderboard.png");
 }
 
 .leaderboard-tabs {
@@ -181,6 +186,11 @@ h1 {
   justify-content: center;
   align-items: center;
   height: 100vh;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+    url("../images/images_background_boost.png");
 }
 
 .boost-container {
@@ -481,16 +491,6 @@ button:active {
   width: 50%;
 }
 
-@media screen and (orientation:portrait) {
-body {
-    transform: rotate(90deg);
-    transform-origin: left top;
-    width: 100vh;
-    height: 100vw;
-    overflow: hidden;
-  }
-}
-
 a {
   text-decoration: none;
   color: inherit;
@@ -540,4 +540,68 @@ a {
 
 .upgrade-button img {
   height: 40vh;
+}
+
+.ephemeral-icon {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  animation: fade 3s forwards;
+  pointer-events: none;
+  z-index: 200;
+}
+
+.ephemeral-icon img {
+  height: 20vh;
+  animation: pulse 0.5s infinite alternate;
+}
+
+@keyframes fade {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.2);
+  }
+}
+
+.rotate-mobile-page {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+    url("../images/images_background_rotatemobile.png");
+}
+
+.rotate-mobile-icon {
+  font-size: 20vh;
+  animation: rotate-mobile 2s infinite linear;
+}
+
+@keyframes rotate-mobile {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -7,7 +7,11 @@ export default function App() {
   const [authenticated, setAuthenticated] = React.useState(false);
   const [soundsOn, setSoundsOn] = React.useState(true);
   const soundsOnRef = React.useRef(soundsOn);
+  window.soundsOnRef = soundsOnRef;
   const [playerData, setPlayerData] = React.useState(null);
+  const [isPortrait, setIsPortrait] = React.useState(
+    window.matchMedia('(orientation: portrait)').matches
+  );
 
   React.useEffect(() => {
     const kc = new Keycloak({
@@ -41,6 +45,23 @@ export default function App() {
   React.useEffect(() => {
     soundsOnRef.current = soundsOn;
   }, [soundsOn]);
+
+  React.useEffect(() => {
+    const mql = window.matchMedia('(orientation: portrait)');
+    const handler = (e) => setIsPortrait(e.matches);
+    if (mql.addEventListener) {
+      mql.addEventListener('change', handler);
+    } else {
+      mql.addListener(handler);
+    }
+    return () => {
+      if (mql.removeEventListener) {
+        mql.removeEventListener('change', handler);
+      } else {
+        mql.removeListener(handler);
+      }
+    };
+  }, []);
 
   React.useEffect(() => {
     const lockLandscape = () => {
@@ -119,6 +140,7 @@ export default function App() {
           playerData={playerData}
           refreshPlayerData={fetchPlayerData}
         />
+        {isPortrait && <RotateMobileOverlay />}
       </HashRouter>
     </LangProvider>
   );
@@ -240,5 +262,13 @@ function StatsBar({ data }) {
         {data.reputation}
       </span>
     </Link>
+  );
+}
+
+function RotateMobileOverlay() {
+  return (
+    <div className="rotate-mobile-page">
+      <i className="fa-solid fa-mobile-screen rotate-mobile-icon"></i>
+    </div>
   );
 }

--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -16,10 +16,20 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
   const [selected, setSelected] = React.useState(null);
   const [scanRange, setScanRange] = React.useState(2);
   const [visibleScans, setVisibleScans] = React.useState(new Set());
+  const [effect, setEffect] = React.useState(null);
   const zoomRef = React.useRef(zoom);
   const centerRef = React.useRef(center);
 
   const apiUrl = window.CONFIG['minesweeper-api-url'];
+
+  React.useEffect(() => {
+    if (!effect) return;
+    if (!window.soundsOnRef || window.soundsOnRef.current) {
+      new Audio(`sounds/${effect.sound}`).play();
+    }
+    const timer = setTimeout(() => setEffect(null), 3000);
+    return () => clearTimeout(timer);
+  }, [effect]);
 
   React.useEffect(() => {
     keycloak
@@ -462,6 +472,7 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
               });
               setMines((prev) => [...prev, mine]);
               setSelected({ x: res.x, y: res.y, scan: null, mine });
+              setEffect({ icon: 'icon_explosion.png', sound: 'sound_explosion.mp3' });
             } else {
               setScans((prev) => [
                 ...prev.filter((s) => !(s.x === res.x && s.y === res.y)),
@@ -479,6 +490,11 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
                 mine: prev.mine,
               }));
               setScanRange(Math.max(res.scanRange ?? 2, 2));
+              if ((res.mineCount ?? 0) > 0) {
+                setEffect({ icon: 'icon_alarm.png', sound: 'sound_warning.mp3' });
+              } else {
+                setEffect({ icon: 'icon_empty_hole.png', sound: 'sound_nothing.mp3' });
+              }
             }
             requestAnimationFrame(draw);
             refreshPlayerData && refreshPlayerData();
@@ -536,6 +552,7 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
                 scan: prev.scan,
                 mine: res,
               }));
+              setEffect({ icon: 'icon_bomb_defused.png', sound: 'sound_click_1.mp3' });
             }
             refreshPlayerData && refreshPlayerData();
           })
@@ -605,6 +622,11 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
               )}
             </>
           )}
+        </div>
+      )}
+      {effect && (
+        <div className="ephemeral-icon">
+          <img src={`images/icons/actions/${effect.icon}`} alt="effect" />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- show transient icon and sound for scan outcomes and successful demining
- add rotating-phone overlay for portrait mode with background
- style boost and leaderboard pages with their respective backgrounds

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891817ce74c832c9e47a5d4b1f5558f