### PR TITLE
Empêcher le rechargement complet lors du scan ou du déminage

### DIFF
--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -591,15 +591,16 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
         onPointerDown={handlePointerDown}
       ></canvas>
       <button
+        type="button"
         className="show-zones-button"
         onClick={() => setVisibleScans(new Set(scans.map((s) => `${s.x},${s.y}`)))}
       >
         <img src="images/icons/actions/icon_eyes_open.png" alt="show" className="icon" />
       </button>
-      <button className="hide-zones-button" onClick={() => setVisibleScans(new Set())}>
+      <button type="button" className="hide-zones-button" onClick={() => setVisibleScans(new Set())}>
         <img src="images/icons/actions/icon_eyes_close.png" alt="hide" className="icon" />
       </button>
-      <button className="refresh-button" onClick={refreshBoard}>
+      <button type="button" className="refresh-button" onClick={refreshBoard}>
         <img src="images/icons/actions/icon_refresh.png" alt="refresh" className="icon" />
       </button>
       {selected && (
@@ -620,6 +621,7 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
                 onChange={(e) => setScanRange(Number(e.target.value))}
               />
               <button
+                type="button"
                 className="main-button"
                 onClick={handleScan}
                 disabled={playerData?.gold <= 0}
@@ -631,7 +633,7 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
                 />
               </button>
               {!selected.scan && (
-                <button className="main-button" onClick={handleDemine}>
+                <button type="button" className="main-button" onClick={handleDemine}>
                   <img
                     src="images/icons/actions/icon_defuse_process.png"
                     alt={t.demine}


### PR DESCRIPTION
## Résumé
- Ajout de l'attribut `type="button"` aux boutons de scan, déminage et contrôle du plateau
- Empêche les soumissions implicites de formulaire et conserve le plateau affiché

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68919a13cd70832c915e0038281a16ef