### PR TITLE
Update client-side board after mine clearance

### DIFF
--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -595,15 +595,20 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
         onPointerDown={handlePointerDown}
       ></canvas>
       <button
+        type="button"
         className="show-zones-button"
         onClick={() => setVisibleScans(new Set(scans.map((s) => `${s.x},${s.y}`)))}
       >
         <img src="images/icons/actions/icon_eyes_open.png" alt="show" className="icon" />
       </button>
-      <button className="hide-zones-button" onClick={() => setVisibleScans(new Set())}>
+      <button
+        type="button"
+        className="hide-zones-button"
+        onClick={() => setVisibleScans(new Set())}
+      >
         <img src="images/icons/actions/icon_eyes_close.png" alt="hide" className="icon" />
       </button>
-      <button className="refresh-button" onClick={refreshBoard}>
+      <button type="button" className="refresh-button" onClick={refreshBoard}>
         <img src="images/icons/actions/icon_refresh.png" alt="refresh" className="icon" />
       </button>
       {selected && (
@@ -624,6 +629,7 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
                 onChange={(e) => setScanRange(Number(e.target.value))}
               />
               <button
+                type="button"
                 className="main-button"
                 onClick={handleScan}
                 disabled={playerData?.gold <= 0}
@@ -635,7 +641,11 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
                 />
               </button>
               {!selected.scan && (
-                <button className="main-button" onClick={handleDemine}>
+                <button
+                  type="button"
+                  className="main-button"
+                  onClick={handleDemine}
+                >
                   <img
                     src="images/icons/actions/icon_defuse_process.png"
                     alt={t.demine}

--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -454,7 +454,9 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
     };
   }, []);
 
-  const handleScan = () => {
+  const handleScan = (e) => {
+    e?.preventDefault();
+    e?.stopPropagation();
     const range = scanRange;
     keycloak
       .updateToken(60)
@@ -517,7 +519,9 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
       .catch(() => {});
   };
 
-  const handleDemine = () => {
+  const handleDemine = (e) => {
+    e?.preventDefault();
+    e?.stopPropagation();
     keycloak
       .updateToken(60)
       .then(() =>

--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -559,19 +559,23 @@ export default function GamePage({ keycloak, playerData, refreshPlayerData }) {
               setScanRange(2);
               requestAnimationFrame(draw);
             } else {
+              setScans((prev) =>
+                prev.filter((s) => !(s.x === res.x && s.y === res.y))
+              );
+              setVisibleScans((prev) => {
+                const next = new Set(prev);
+                next.delete(`${res.x},${res.y}`);
+                return next;
+              });
               setMines((prev) => [...prev, res]);
-              setSelected((prev) => ({
-                x: res.x,
-                y: res.y,
-                scan: prev.scan,
-                mine: res,
-              }));
+              setSelected({ x: res.x, y: res.y, scan: null, mine: res });
               const pos = getEffectPosition(res.x, res.y);
               setEffect({
                 icon: 'icon_bomb_defused.png',
                 sound: 'sound_click_1.mp3',
                 ...pos,
               });
+              requestAnimationFrame(draw);
             }
             refreshPlayerData && refreshPlayerData();
           })


### PR DESCRIPTION
## Summary
- Avoid redundant GET calls after clearing a mine by updating client state in place
- Remove any existing scan for the cleared cell and redraw board when a mine is defused

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable import POM: could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_6891de735dc8832cb4ed7ec3e145cf8b