### PR TITLE
Centralize Keycloak authentication logic

### DIFF
--- a/minesweeper-ui/js/keycloak.js
+++ b/minesweeper-ui/js/keycloak.js
@@ -1,0 +1,63 @@
+const KeycloakCtor = window.Keycloak;
+
+const keycloak = new KeycloakCtor({
+  url: window.CONFIG['auth-url'],
+  realm: window.CONFIG['auth-realm'],
+  clientId: window.CONFIG['auth-client-id'],
+});
+
+let refreshInterval;
+
+export async function init() {
+  const authenticated = await keycloak
+    .init({ onLoad: 'check-sso', checkLoginIframe: false })
+    .catch(() => false);
+  if (authenticated) {
+    startTokenRefresh();
+  }
+  setupFetchInterceptor();
+  return authenticated;
+}
+
+function startTokenRefresh() {
+  refreshInterval = setInterval(() => {
+    keycloak.updateToken(60).catch(() => {
+      keycloak.clearToken();
+    });
+  }, 10000);
+}
+
+function setupFetchInterceptor() {
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (url, options = {}) => {
+    if (keycloak.token) {
+      try {
+        await keycloak.updateToken(60);
+      } catch {
+        keycloak.clearToken();
+      }
+    }
+    const headers = new Headers(options.headers || {});
+    if (keycloak.token) {
+      headers.set('Authorization', `Bearer ${keycloak.token}`);
+    }
+    return originalFetch(url, { ...options, headers });
+  };
+}
+
+export const login = (options) => keycloak.login(options);
+export const logout = (options) => {
+  clearInterval(refreshInterval);
+  return keycloak.logout(options);
+};
+
+export const hasRealmRole = (role) =>
+  keycloak && keycloak.hasRealmRole && keycloak.hasRealmRole(role);
+export const hasResourceRole = (role, resource) =>
+  keycloak &&
+  keycloak.hasResourceRole &&
+  keycloak.hasResourceRole(role, resource);
+
+export const getUserId = () => keycloak.tokenParsed?.sub;
+
+export default keycloak;

--- a/minesweeper-ui/js/pages/BoostPage.js
+++ b/minesweeper-ui/js/pages/BoostPage.js
@@ -1,19 +1,13 @@
-export default function BoostPage({ keycloak, refreshPlayerData }) {
+export default function BoostPage({ refreshPlayerData }) {
   const apiUrl = window.CONFIG['minesweeper-api-url'];
   const buy = (amount) => {
-    keycloak
-      .updateToken(60)
-      .then(() =>
-        fetch(`${apiUrl}/player-data/me/add-gold`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${keycloak.token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ amount }),
-        }).then(() => refreshPlayerData())
-      )
-      .catch(() => {});
+    fetch(`${apiUrl}/player-data/me/add-gold`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ amount }),
+    }).then(() => refreshPlayerData());
   };
   const items = [
     { icon: 'icon_buy_small.png', gold: 1000, price: '1.99€' },

--- a/minesweeper-ui/js/pages/GamesListPage.js
+++ b/minesweeper-ui/js/pages/GamesListPage.js
@@ -1,28 +1,24 @@
 const { Link } = ReactRouterDOM;
 import { LangContext } from '../i18n.js';
+import { hasRealmRole, hasResourceRole } from '../keycloak.js';
 
-export default function GamesListPage({ keycloak }) {
+export default function GamesListPage() {
   const { t } = React.useContext(LangContext);
   const [games, setGames] = React.useState(null);
 
   const loadGames = React.useCallback(() => {
-    fetch(`${window.CONFIG['minesweeper-api-url']}/games`, {
-      headers: { Authorization: `Bearer ${keycloak.token}` },
-    })
+    fetch(`${window.CONFIG['minesweeper-api-url']}/games`)
       .then((r) => r.json())
       .then(setGames)
       .catch(() => setGames([]));
-  }, [keycloak]);
+  }, []);
 
   React.useEffect(() => {
     loadGames();
   }, [loadGames]);
 
   const isAdmin =
-    (keycloak && keycloak.hasRealmRole && keycloak.hasRealmRole('admin')) ||
-    (keycloak &&
-      keycloak.hasResourceRole &&
-      keycloak.hasResourceRole('admin', 'minesweeper-app'));
+    hasRealmRole('admin') || hasResourceRole('admin', 'minesweeper-app');
 
   const formatRemaining = React.useCallback(
     (date) => {
@@ -52,9 +48,7 @@ export default function GamesListPage({ keycloak }) {
           <div className="no-games-message">
             <p>{t.noGame}</p>
           </div>
-          {isAdmin && (
-            <CreateGameForm keycloak={keycloak} onGameCreated={loadGames} />
-          )}
+          {isAdmin && <CreateGameForm onGameCreated={loadGames} />}
         </div>
       ) : (
         <div className="games-page">
@@ -91,16 +85,14 @@ export default function GamesListPage({ keycloak }) {
               ))}
             </ul>
           </div>
-          {isAdmin && (
-            <CreateGameForm keycloak={keycloak} onGameCreated={loadGames} />
-          )}
+          {isAdmin && <CreateGameForm onGameCreated={loadGames} />}
         </div>
       )}
     </div>
   );
 }
 
-function CreateGameForm({ keycloak, onGameCreated }) {
+function CreateGameForm({ onGameCreated }) {
   const { t } = React.useContext(LangContext);
   const [show, setShow] = React.useState(false);
   const [form, setForm] = React.useState({
@@ -121,7 +113,6 @@ function CreateGameForm({ keycloak, onGameCreated }) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${keycloak.token}`,
       },
       body: JSON.stringify({
         title: form.title,

--- a/minesweeper-ui/js/pages/InfoPage.js
+++ b/minesweeper-ui/js/pages/InfoPage.js
@@ -1,6 +1,6 @@
 import { LangContext } from '../i18n.js';
 
-export default function InfoPage({ keycloak, playerData, refreshPlayerData }) {
+export default function InfoPage({ playerData, refreshPlayerData }) {
   const { t } = React.useContext(LangContext);
   const apiUrl = window.CONFIG['minesweeper-api-url'];
 
@@ -9,7 +9,6 @@ export default function InfoPage({ keycloak, playerData, refreshPlayerData }) {
   const upgradeScan = () => {
     fetch(`${apiUrl}/player-data/me/upgrade-scan`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${keycloak.token}` },
     })
       .then((r) => r.json())
       .then(() => refreshPlayerData());
@@ -18,7 +17,6 @@ export default function InfoPage({ keycloak, playerData, refreshPlayerData }) {
   const upgradeIncome = () => {
     fetch(`${apiUrl}/player-data/me/upgrade-income`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${keycloak.token}` },
     })
       .then((r) => r.json())
       .then(() => refreshPlayerData());

--- a/minesweeper-ui/js/pages/LeaderboardPage.js
+++ b/minesweeper-ui/js/pages/LeaderboardPage.js
@@ -1,25 +1,18 @@
 const { useState, useEffect } = React;
 import { LangContext } from '../i18n.js';
 
-export default function LeaderboardPage({ keycloak }) {
+export default function LeaderboardPage() {
   const { t } = React.useContext(LangContext);
   const [period, setPeriod] = useState('daily');
   const [data, setData] = useState([]);
   const apiUrl = window.CONFIG['minesweeper-api-url'];
 
   const load = React.useCallback(() => {
-    keycloak
-      .updateToken(60)
-      .then(() =>
-        fetch(`${apiUrl}/leaderboard/${period}`, {
-          headers: { Authorization: `Bearer ${keycloak.token}` },
-        })
-          .then((r) => r.json())
-          .then(setData)
-          .catch(() => setData([]))
-      )
+    fetch(`${apiUrl}/leaderboard/${period}`)
+      .then((r) => r.json())
+      .then(setData)
       .catch(() => setData([]));
-  }, [apiUrl, period, keycloak]);
+  }, [apiUrl, period]);
 
   useEffect(() => {
     load();

--- a/minesweeper-ui/js/pages/SettingsPage.js
+++ b/minesweeper-ui/js/pages/SettingsPage.js
@@ -1,18 +1,16 @@
 import { LangContext } from '../i18n.js';
 
-export default function SettingsPage({ authenticated, keycloak, onLogout, soundsOn, toggleSounds }) {
+export default function SettingsPage({ authenticated, onLogout, soundsOn, toggleSounds }) {
   const { lang, changeLang, t } = React.useContext(LangContext);
   const [name, setName] = React.useState('');
 
   React.useEffect(() => {
     if (!authenticated) return;
-    fetch(`${window.CONFIG['minesweeper-api-url']}/players/me`, {
-      headers: { Authorization: `Bearer ${keycloak.token}` },
-    })
+    fetch(`${window.CONFIG['minesweeper-api-url']}/players/me`)
       .then((r) => r.json())
       .then((p) => setName(p.name))
       .catch(() => {});
-  }, [authenticated, keycloak]);
+  }, [authenticated]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -20,7 +18,6 @@ export default function SettingsPage({ authenticated, keycloak, onLogout, sounds
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${keycloak.token}`,
       },
       body: JSON.stringify({ name }),
     });

--- a/minesweeper-ui/js/router.js
+++ b/minesweeper-ui/js/router.js
@@ -7,7 +7,7 @@ import InfoPage from './pages/InfoPage.js';
 import LeaderboardPage from './pages/LeaderboardPage.js';
 import BoostPage from './pages/BoostPage.js';
 
-export default function AppRouter({ authenticated, keycloak, login, soundsOn, toggleSounds, playerData, refreshPlayerData }) {
+export default function AppRouter({ authenticated, login, logout, soundsOn, toggleSounds, playerData, refreshPlayerData }) {
   const RequireAuth = ({ children }) =>
     authenticated ? children : <Navigate to="/login" />;
 
@@ -29,9 +29,8 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         element={
           <SettingsPage
             authenticated={authenticated}
-            keycloak={keycloak}
             onLogout={() =>
-              keycloak.logout({
+              logout({
                 redirectUri: window.location.href.split('#')[0] + '#/login',
               })
             }
@@ -44,7 +43,7 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         path="/"
         element={
           <RequireAuth>
-            <GamesListPage keycloak={keycloak} />
+            <GamesListPage />
           </RequireAuth>
         }
       />
@@ -52,7 +51,7 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         path="/games/:id"
         element={
           <RequireAuth>
-            <GamePage keycloak={keycloak} playerData={playerData} refreshPlayerData={refreshPlayerData} />
+            <GamePage playerData={playerData} refreshPlayerData={refreshPlayerData} />
           </RequireAuth>
         }
       />
@@ -60,7 +59,7 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         path="/info"
         element={
           <RequireAuth>
-            <InfoPage keycloak={keycloak} playerData={playerData} refreshPlayerData={refreshPlayerData} />
+            <InfoPage playerData={playerData} refreshPlayerData={refreshPlayerData} />
           </RequireAuth>
         }
       />
@@ -68,7 +67,7 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         path="/leaderboard"
         element={
           <RequireAuth>
-            <LeaderboardPage keycloak={keycloak} />
+            <LeaderboardPage />
           </RequireAuth>
         }
       />
@@ -76,7 +75,7 @@ export default function AppRouter({ authenticated, keycloak, login, soundsOn, to
         path="/boost"
         element={
           <RequireAuth>
-            <BoostPage keycloak={keycloak} refreshPlayerData={refreshPlayerData} />
+            <BoostPage refreshPlayerData={refreshPlayerData} />
           </RequireAuth>
         }
       />


### PR DESCRIPTION
## Summary
- add `keycloak.js` helper to handle login/logout, token refresh and bearer injection
- refactor app and pages to use centralized Keycloak logic
- remove scattered token refresh calls and manual auth headers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68922ccf5378832c913684d1c80bed7c