### PR TITLE
Embed stats bar per page and tweak style

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -50,7 +50,6 @@ h1 {
   position: fixed;
   top: 0;
   left: 0;
-  width: 80%;
   text-align: left;
   font-size: 10vh;
   padding: 0.25rem 0;

--- a/minesweeper-ui/js/App.js
+++ b/minesweeper-ui/js/App.js
@@ -98,7 +98,6 @@ export default function App() {
   return (
     <LangProvider>
       <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-        {authenticated && playerData && <StatsBar data={playerData} />}
         <SettingsButton />
         <GamesListButton />
         <LeaderboardButton />
@@ -202,37 +201,6 @@ function BoostButton() {
         alt="Boost"
         className="icon"
       />
-    </Link>
-  );
-}
-
-function StatsBar({ data }) {
-  return (
-    <Link to="/info" className="stats-bar">
-      <span>
-        <img
-          src="images/icons/actions/icon_portfolio.png"
-          alt="Gold"
-          className="icon"
-        />{' '}
-        {data.gold}
-      </span>{' '}
-      <span>
-        <img
-          src="images/icons/actions/icon_scanner_power.png"
-          alt="Scan"
-          className="icon"
-        />{' '}
-        {data.scanRangeMax}
-      </span>{' '}
-      <span>
-        <img
-          src="images/icons/actions/icon_medal.png"
-          alt="Reputation"
-          className="icon"
-        />{' '}
-        {data.reputation}
-      </span>
     </Link>
   );
 }

--- a/minesweeper-ui/js/StatsBar.js
+++ b/minesweeper-ui/js/StatsBar.js
@@ -1,0 +1,32 @@
+const { Link } = ReactRouterDOM;
+
+export default function StatsBar({ data }) {
+  return (
+    <Link to="/info" className="stats-bar">
+      <span>
+        <img
+          src="images/icons/actions/icon_portfolio.png"
+          alt="Gold"
+          className="icon"
+        />{' '}
+        {data.gold}
+      </span>{' '}
+      <span>
+        <img
+          src="images/icons/actions/icon_scanner_power.png"
+          alt="Scan"
+          className="icon"
+        />{' '}
+        {data.scanRangeMax}
+      </span>{' '}
+      <span>
+        <img
+          src="images/icons/actions/icon_medal.png"
+          alt="Reputation"
+          className="icon"
+        />{' '}
+        {data.reputation}
+      </span>
+    </Link>
+  );
+}

--- a/minesweeper-ui/js/pages/BoostPage.js
+++ b/minesweeper-ui/js/pages/BoostPage.js
@@ -1,4 +1,6 @@
-export default function BoostPage({ refreshPlayerData }) {
+import StatsBar from '../StatsBar.js';
+
+export default function BoostPage({ playerData, refreshPlayerData }) {
   const apiUrl = window.CONFIG['minesweeper-api-url'];
   const buy = (amount) => {
     fetch(`${apiUrl}/player-data/me/add-gold`, {
@@ -16,6 +18,7 @@ export default function BoostPage({ refreshPlayerData }) {
   ];
   return (
     <div className="boost-page">
+      {playerData && <StatsBar data={playerData} />}
       <div className="boost-container">
         {items.map((it) => (
           <div key={it.gold} className="boost-item" onClick={() => buy(it.gold)}>

--- a/minesweeper-ui/js/pages/GamePage.js
+++ b/minesweeper-ui/js/pages/GamePage.js
@@ -1,6 +1,7 @@
 const { useParams } = ReactRouterDOM;
 import { LangContext } from '../i18n.js';
 import { getUserId } from '../keycloak.js';
+import StatsBar from '../StatsBar.js';
 
 export default function GamePage({ playerData, refreshPlayerData }) {
   const { id } = useParams();
@@ -559,6 +560,7 @@ export default function GamePage({ playerData, refreshPlayerData }) {
 
   return (
     <div className="game-page">
+      {playerData && <StatsBar data={playerData} />}
       <canvas
         ref={canvasRef}
         className="game-canvas"

--- a/minesweeper-ui/js/pages/GamesListPage.js
+++ b/minesweeper-ui/js/pages/GamesListPage.js
@@ -1,8 +1,9 @@
 const { Link } = ReactRouterDOM;
 import { LangContext } from '../i18n.js';
 import { hasRealmRole, hasResourceRole } from '../keycloak.js';
+import StatsBar from '../StatsBar.js';
 
-export default function GamesListPage() {
+export default function GamesListPage({ playerData }) {
   const { t } = React.useContext(LangContext);
   const [games, setGames] = React.useState(null);
 
@@ -43,6 +44,7 @@ export default function GamesListPage() {
 
   return (
     <div>
+      {playerData && <StatsBar data={playerData} />}
       {games.length === 0 ? (
         <div className="no-games">
           <div className="no-games-message">

--- a/minesweeper-ui/js/pages/InfoPage.js
+++ b/minesweeper-ui/js/pages/InfoPage.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import StatsBar from '../StatsBar.js';
 
 export default function InfoPage({ playerData, refreshPlayerData }) {
   const { t } = React.useContext(LangContext);
@@ -27,6 +28,7 @@ export default function InfoPage({ playerData, refreshPlayerData }) {
 
   return (
     <div className="info-page">
+      <StatsBar data={playerData} />
       <div className="income-line">
         {t.dailyIncome}: {playerData.incomePerDay} {t.gold}
       </div>

--- a/minesweeper-ui/js/pages/LeaderboardPage.js
+++ b/minesweeper-ui/js/pages/LeaderboardPage.js
@@ -1,7 +1,8 @@
 const { useState, useEffect } = React;
 import { LangContext } from '../i18n.js';
+import StatsBar from '../StatsBar.js';
 
-export default function LeaderboardPage() {
+export default function LeaderboardPage({ playerData }) {
   const { t } = React.useContext(LangContext);
   const [period, setPeriod] = useState('daily');
   const [data, setData] = useState([]);
@@ -27,6 +28,7 @@ export default function LeaderboardPage() {
 
   return (
     <div className="leaderboard-page">
+      {playerData && <StatsBar data={playerData} />}
       <div className="leaderboard-tabs">
         {['daily', 'weekly', 'monthly'].map((p) => (
           <button

--- a/minesweeper-ui/js/pages/SettingsPage.js
+++ b/minesweeper-ui/js/pages/SettingsPage.js
@@ -1,6 +1,7 @@
 import { LangContext } from '../i18n.js';
+import StatsBar from '../StatsBar.js';
 
-export default function SettingsPage({ authenticated, onLogout, soundsOn, toggleSounds }) {
+export default function SettingsPage({ authenticated, onLogout, soundsOn, toggleSounds, playerData }) {
   const { lang, changeLang, t } = React.useContext(LangContext);
   const [name, setName] = React.useState('');
 
@@ -25,6 +26,7 @@ export default function SettingsPage({ authenticated, onLogout, soundsOn, toggle
 
   return (
     <div className="settings-page">
+      {authenticated && playerData && <StatsBar data={playerData} />}
       <div className="language-selection">
         <button
           className={`flag-button ${lang === 'en' ? 'active' : ''}`}

--- a/minesweeper-ui/js/router.js
+++ b/minesweeper-ui/js/router.js
@@ -36,6 +36,7 @@ export default function AppRouter({ authenticated, login, logout, soundsOn, togg
             }
             soundsOn={soundsOn}
             toggleSounds={toggleSounds}
+            playerData={playerData}
           />
         }
       />
@@ -43,7 +44,7 @@ export default function AppRouter({ authenticated, login, logout, soundsOn, togg
         path="/"
         element={
           <RequireAuth>
-            <GamesListPage />
+            <GamesListPage playerData={playerData} />
           </RequireAuth>
         }
       />
@@ -67,7 +68,7 @@ export default function AppRouter({ authenticated, login, logout, soundsOn, togg
         path="/leaderboard"
         element={
           <RequireAuth>
-            <LeaderboardPage />
+            <LeaderboardPage playerData={playerData} />
           </RequireAuth>
         }
       />
@@ -75,7 +76,7 @@ export default function AppRouter({ authenticated, login, logout, soundsOn, togg
         path="/boost"
         element={
           <RequireAuth>
-            <BoostPage refreshPlayerData={refreshPlayerData} />
+            <BoostPage playerData={playerData} refreshPlayerData={refreshPlayerData} />
           </RequireAuth>
         }
       />


### PR DESCRIPTION
## Summary
- Move stats bar into a dedicated component and include it on each page
- Remove width constraint from `.stats-bar` styling for flexible layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892b8c0c08c832c89fa13ee11a0393e