### PR TITLE
feat: ensure app loads after timeout

### DIFF
--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -41,12 +41,17 @@
       const loading = document.getElementById('loading-screen');
 
       function showApp() {
+        clearTimeout(fallbackTimeout);
         loading.style.display = 'none';
         root.style.display = 'block';
       }
 
+      let fallbackTimeout;
       if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('service-worker.js');
+        fallbackTimeout = setTimeout(showApp, 10000);
+        navigator.serviceWorker
+          .register('service-worker.js')
+          .catch(() => showApp());
         navigator.serviceWorker.addEventListener('message', (event) => {
           if (event.data === 'CACHE_COMPLETE') {
             showApp();


### PR DESCRIPTION
## Summary
- show app even if service worker registration fails
- add 10s fallback timer so the app loads after waiting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892d44049b4832cb709464785940aa4