### PR TITLE
Adjust log placement and stop redundant login events

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/PlayerDataResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PlayerDataResource.java
@@ -4,7 +4,6 @@ import com.minesweeper.dto.PlayerDataInfo;
 import com.minesweeper.dto.AddGoldRequest;
 import com.minesweeper.entity.PlayerData;
 import com.minesweeper.repository.PlayerDataRepository;
-import com.minesweeper.service.EventPublisher;
 import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -28,8 +27,6 @@ public class PlayerDataResource {
     @Inject
     JsonWebToken jwt;
 
-    @Inject
-    EventPublisher eventPublisher;
 
     private PlayerData getOrCreate(String id) {
         PlayerData data = playerDataRepository.findById(id);
@@ -52,7 +49,6 @@ public class PlayerDataResource {
     public PlayerDataInfo me() {
         String id = jwt.getSubject();
         PlayerData data = getOrCreate(id);
-        eventPublisher.publishGlobal("LOGIN", id, jwt.getClaim("name"), new io.vertx.core.json.JsonObject());
         return new PlayerDataInfo(data.getReputation(), data.getGold(), data.getScanRangeMax(), data.getIncomePerDay());
         }
 

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -9,7 +9,7 @@ body {
 
 .event-log {
   position: fixed;
-  bottom: 10px;
+  bottom: 20vh;
   left: 10px;
   max-width: 300px;
   font-size: 14px;


### PR DESCRIPTION
## Summary
- place event logs 20vh above the bottom of the viewport
- remove global LOGIN event publication when retrieving player data to prevent repeated login messages

## Testing
- `npm test`
- `mvn test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_689304ae0a98832cb50cfb5df2700e60