### PR TITLE
Include exploded mines in progress count and sort games by remaining time

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/GameResource.java
@@ -32,7 +32,7 @@ public class GameResource {
     public List<GameInfo> listGames() {
         return gameRepository.listOngoing().stream()
                 .map(g -> {
-                    long found = mineRepository.count("game = ?1 and foundBy is not null", g);
+                    long found = mineRepository.count("game = ?1 and (foundBy is not null or exploded = true)", g);
                     return new GameInfo(
                             g.getId(),
                             g.getTitle(),

--- a/minesweeper-api/src/main/java/com/minesweeper/repository/GameRepository.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/repository/GameRepository.java
@@ -12,7 +12,7 @@ public class GameRepository implements PanacheRepositoryBase<Game, String> {
 
     public List<Game> listOngoing() {
         LocalDateTime now = LocalDateTime.now();
-        return list("startDate <= ?1 and endDate >= ?1", now);
+        return list("startDate <= ?1 and endDate >= ?1 order by endDate asc", now);
     }
 }
 


### PR DESCRIPTION
## Summary
- Count exploded mines in ongoing game details so progress reflects both defused and exploded mines
- Order ongoing games by soonest end date for clearer prioritization

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable import POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68932468db78832c8424d0c6904af6ca