### PR TITLE
fix: improve UI spacing and player names

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/ScanResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/ScanResource.java
@@ -56,7 +56,9 @@ public class ScanResource {
         if (game == null) {
             throw new NotFoundException();
         }
-        eventPublisher.publishGlobal("LOADING_MAP", jwt.getSubject(), jwt.getClaim("name"),
+        Player currentPlayer = playerRepository.findById(jwt.getSubject());
+        String playerName = currentPlayer != null ? currentPlayer.getName() : jwt.getClaim("name");
+        eventPublisher.publishGlobal("LOADING_MAP", jwt.getSubject(), playerName,
                 new io.vertx.core.json.JsonObject()
                         .put("game-id", game.getId())
                         .put("title", game.getTitle()));

--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -394,11 +394,11 @@ button:active {
 }
 
 .games-list-container {
-  display: flex;
   justify-content: center;
   align-items: center;
   flex: 1;
   overflow: auto;
+  margin-top: 15vh;
 }
 
 .games-list {

--- a/minesweeper-ui/public/service-worker.js
+++ b/minesweeper-ui/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'minesweeper-cache-v2';
+const CACHE_NAME = 'minesweeper-cache-v3';
 const ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- add margin on games list container and drop flex display
- use persisted player name when broadcasting events
- bump service worker cache version to force refresh

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6893292e4a28832cb1d57c410d03cd38