### PR TITLE
feat: add install option on rotate screen

### DIFF
--- a/minesweeper-ui/css/main.css
+++ b/minesweeper-ui/css/main.css
@@ -602,6 +602,52 @@ a {
   animation: rotate-mobile 2s infinite linear;
 }
 
+.install-banner {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.install-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.install-card img {
+  width: 64px;
+  height: 64px;
+  border-radius: 8px;
+}
+
+.install-name {
+  margin-top: 4px;
+  font-size: 14px;
+}
+
+.install-action {
+  background-color: #01875f;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.install-action:active {
+  background-color: #01694a;
+}
+
+.install-instructions {
+  max-width: 80vw;
+  font-size: 14px;
+}
+
 @keyframes rotate-mobile {
   from {
     transform: rotate(0deg);

--- a/minesweeper-ui/js/locales/en.js
+++ b/minesweeper-ui/js/locales/en.js
@@ -35,5 +35,8 @@ export default {
   "hourShort": "h",
   "minuteShort": "m",
   "secondShort": "s",
-  "rotateDevice": "Please rotate your device"
+  "rotateDevice": "Please rotate your device",
+  "install": "Install",
+  "installInstructionsIos": "To install the app, open the Share menu and add to Home Screen.",
+  "gameName": "Minesweeper MMO"
 };

--- a/minesweeper-ui/js/locales/en.js
+++ b/minesweeper-ui/js/locales/en.js
@@ -38,5 +38,5 @@ export default {
   "rotateDevice": "Please rotate your device",
   "install": "Install",
   "installInstructionsIos": "To install the app, open the Share menu and add to Home Screen.",
-  "gameName": "Minesweeper MMO"
+  "gameName": "Mine Sweeper Crew"
 };

--- a/minesweeper-ui/js/locales/fr.js
+++ b/minesweeper-ui/js/locales/fr.js
@@ -35,5 +35,8 @@ export default {
   "hourShort": "h",
   "minuteShort": "min",
   "secondShort": "s",
-  "rotateDevice": "Veuillez passer votre appareil en mode paysage"
+  "rotateDevice": "Veuillez passer votre appareil en mode paysage",
+  "install": "Installer",
+  "installInstructionsIos": "Pour installer l'application, ouvrez le menu Partager puis \u00AB\u00A0Ajouter \u00E0 l'\u00E9cran d'accueil\u00A0\u00BB.",
+  "gameName": "Minesweeper MMO"
 };

--- a/minesweeper-ui/js/locales/fr.js
+++ b/minesweeper-ui/js/locales/fr.js
@@ -38,5 +38,5 @@ export default {
   "rotateDevice": "Veuillez passer votre appareil en mode paysage",
   "install": "Installer",
   "installInstructionsIos": "Pour installer l'application, ouvrez le menu Partager puis \u00AB\u00A0Ajouter \u00E0 l'\u00E9cran d'accueil\u00A0\u00BB.",
-  "gameName": "Minesweeper MMO"
+  "gameName": "Mine Sweeper Crew"
 };

--- a/minesweeper-ui/js/pages/RotateMobilePage.js
+++ b/minesweeper-ui/js/pages/RotateMobilePage.js
@@ -44,7 +44,7 @@ export default function RotateMobilePage() {
             installPrompt && (
               <>
                 <div className="install-card">
-                  <img src="images/icons/icon-192.png" alt="Minesweeper MMO" />
+                  <img src="images/icons/icon-192.png" alt={t.gameName} />
                   <div className="install-name">{t.gameName}</div>
                 </div>
                 <button className="install-action" onClick={handleInstall}>

--- a/minesweeper-ui/js/pages/RotateMobilePage.js
+++ b/minesweeper-ui/js/pages/RotateMobilePage.js
@@ -2,5 +2,59 @@ import { LangContext } from '../i18n.js';
 
 export default function RotateMobilePage() {
   const { t } = React.useContext(LangContext);
-  return <div className="rotate-mobile-page">{t.rotateDevice}</div>;
+  const [installPrompt, setInstallPrompt] = React.useState(null);
+  const [isStandalone, setIsStandalone] = React.useState(false);
+  const [isIos, setIsIos] = React.useState(false);
+
+  React.useEffect(() => {
+    const standalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      window.navigator.standalone;
+    setIsStandalone(standalone);
+
+    const ios = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+    setIsIos(ios);
+
+    if (window.deferredPrompt) {
+      setInstallPrompt(window.deferredPrompt);
+    }
+    const handler = (e) => {
+      e.preventDefault();
+      setInstallPrompt(e);
+      window.deferredPrompt = e;
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  const handleInstall = () => {
+    if (!installPrompt) return;
+    installPrompt.prompt();
+    installPrompt.userChoice.finally(() => setInstallPrompt(null));
+  };
+
+  return (
+    <div className="rotate-mobile-page">
+      <div>{t.rotateDevice}</div>
+      {!isStandalone && (
+        <div className="install-banner">
+          {isIos ? (
+            <div className="install-instructions">{t.installInstructionsIos}</div>
+          ) : (
+            installPrompt && (
+              <>
+                <div className="install-card">
+                  <img src="images/icons/icon-192.png" alt="Minesweeper MMO" />
+                  <div className="install-name">{t.gameName}</div>
+                </div>
+                <button className="install-action" onClick={handleInstall}>
+                  {t.install}
+                </button>
+              </>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add Google Play-style install banner to rotate screen
- localize install strings and iOS instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68936d426734832c90719466134e9a16