### PR TITLE
feat: ensure cache readiness for active service worker

### DIFF
--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -74,11 +74,14 @@
           .register('service-worker.js')
           .catch(() => showApp());
         navigator.serviceWorker.ready.then((reg) => {
-          reg.active &&
+          if (reg.active) {
             reg.active.postMessage({
               type: 'init-global',
               apiUrl: window.CONFIG['minesweeper-api-url'],
             });
+            cacheReady = true;
+            checkReady();
+          }
         });
         navigator.serviceWorker.addEventListener('message', (event) => {
           const msg = event.data;

--- a/minesweeper-ui/public/service-worker.js
+++ b/minesweeper-ui/public/service-worker.js
@@ -131,6 +131,16 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.waitUntil(
+      (async () => {
+        const client = await self.clients.get(event.clientId);
+        if (client) {
+          client.postMessage('CACHE_COMPLETE');
+        }
+      })()
+    );
+  }
   event.respondWith(
     caches.match(event.request).then((response) => {
       if (!response) {


### PR DESCRIPTION
## Summary
- set cacheReady when an existing service worker is ready so the app shows without timeout
- notify new clients with CACHE_COMPLETE on navigation fetches

## Testing
- `npm test`
- `npm run build`
- `mvn -q test` *(fails: dependencies.dependency.version is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68942588de0c832cae85df79297ff491