### PR TITLE
Fix loading screen progress bar initialization

### DIFF
--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -25,7 +25,7 @@
   <body>
     <div id="loading-screen">
       <div id="loading-label">Loading / Chargement...</div>
-      <progress id="cache-progress" value="0" max="0"></progress>
+      <progress id="cache-progress" value="0" max="1"></progress>
       <div id="cache-status" style="font-size: small;"></div>
     </div>
     <div id="root" style="display: none"></div>
@@ -89,6 +89,7 @@
             cacheReady = true;
             checkReady();
           } else if (msg && msg.type === 'CACHE_INIT') {
+            progress.value = 0;
             progress.max = msg.total;
           } else if (msg && msg.type === 'CACHE_START') {
             cacheStatus.textContent = msg.asset;


### PR DESCRIPTION
## Summary
- ensure loading screen progress bar starts empty and updates correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d20cd1b8832cb7c8543ce3d910dc