### PR TITLE
Reduce fallback delay before showing UI

### DIFF
--- a/minesweeper-ui/public/index.html
+++ b/minesweeper-ui/public/index.html
@@ -69,7 +69,7 @@
 
       let fallbackTimeout;
       if ('serviceWorker' in navigator) {
-        fallbackTimeout = setTimeout(showApp, 10000);
+        fallbackTimeout = setTimeout(showApp, 1000);
         navigator.serviceWorker
           .register('service-worker.js')
           .catch(() => showApp());


### PR DESCRIPTION
## Summary
- shorten UI service worker fallback timeout from 10s to 1s for quicker startup

## Testing
- `npm test`
- `mvn -q test` *(fails: 'dependencies.dependency.version' missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894d719d3f4832cbe7895693b5eca64