### PR TITLE
Use PayPal custom field for user tracking

### DIFF
--- a/minesweeper-api/src/main/java/com/minesweeper/PaymentResource.java
+++ b/minesweeper-api/src/main/java/com/minesweeper/PaymentResource.java
@@ -157,7 +157,7 @@ public class PaymentResource {
         paymentTrackingRepository.persist(tracking);
         try {
             String token = getToken();
-            String body = String.format("{\"amount\": %s, \"id-user\": \"%s\"}", amount, userId);
+            String body = String.format("{\"amount\": %s, \"custom\": \"%s\"}", amount, userId);
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create(paymentApi + "/paypal-ipn/init"))
                     .header("Authorization", "Bearer " + token)

--- a/minesweeper-ui/js/pages/BoostPage.js
+++ b/minesweeper-ui/js/pages/BoostPage.js
@@ -56,7 +56,7 @@ export default function BoostPage({ refreshPlayerData }) {
       .then((res) => {
         if (res.status === 200) {
           const userId = getUserId();
-          const winUrl = `${item.url}?id-user=${encodeURIComponent(userId)}`;
+          const winUrl = `${item.url}?custom=${encodeURIComponent(userId)}`;
           window.open(winUrl, '_blank');
           const intervalId = setInterval(() => {
             checkPayment(intervalId);


### PR DESCRIPTION
## Summary
- send PayPal user id via `custom` query parameter on boost purchase
- forward `custom` field to payment API when initializing PayPal IPN

## Testing
- `npm test`
- `mvn -q test` *(fails: dependencies.dependency.version missing)*

------
https://chatgpt.com/codex/tasks/task_e_68963ad2947c832c9398f76c2899311e